### PR TITLE
Fix tests and add FarmPlot coverage

### DIFF
--- a/__tests__/Enemy.test.js
+++ b/__tests__/Enemy.test.js
@@ -29,7 +29,7 @@ describe('Enemy', () => {
         enemy.dealDamage(target);
         Math.random = originalRandom;
 
-        expect(target.takeDamage).toHaveBeenCalledWith('head', 8, true);
+        expect(target.takeDamage).toHaveBeenCalledWith('head', 8, true, enemy);
     });
 
     test('update attacks target when in range', () => {

--- a/__tests__/EventManager.test.js
+++ b/__tests__/EventManager.test.js
@@ -25,7 +25,7 @@ describe('EventManager', () => {
     test('update triggers random event when interval reached', () => {
         const manager = new EventManager(game, EnemyStub);
         jest.spyOn(manager, 'triggerRandomEvent').mockImplementation(() => {});
-        manager.update(61000); // exceed eventInterval of 60s
+        manager.update(1201000); // exceed eventInterval of 1200s
         expect(manager.triggerRandomEvent).toHaveBeenCalled();
     });
 
@@ -45,7 +45,7 @@ describe('EventManager', () => {
     test('Resource Discovery adds resource and notification', () => {
         const manager = new EventManager(game, EnemyStub);
         jest.spyOn(Math, 'random')
-            .mockReturnValueOnce(0.5) // pick second event
+            .mockReturnValueOnce(0.3) // pick Resource Discovery event
             .mockReturnValueOnce(0)    // pick resource index 0 -> wood
             .mockReturnValueOnce(0);    // quantity -> 20
         manager.triggerRandomEvent();

--- a/__tests__/FarmPlot.test.js
+++ b/__tests__/FarmPlot.test.js
@@ -1,0 +1,33 @@
+import FarmPlot from '../src/js/farmPlot.js';
+import SpriteManager from '../src/js/spriteManager.js';
+
+describe('FarmPlot', () => {
+    let farm;
+    beforeEach(() => {
+        farm = new FarmPlot(0, 0, new SpriteManager());
+    });
+
+    test('plant sets crop and stage', () => {
+        expect(farm.plant('wheat')).toBe(true);
+        expect(farm.crop).toBe('wheat');
+        expect(farm.growthStage).toBe(1);
+        expect(farm.plant('wheat')).toBe(false);
+    });
+
+    test('update advances growth and matures', () => {
+        farm.plant('wheat');
+        farm.update(1000); // 1 second -> growthRate 0.01
+        expect(farm.growthStage).toBeGreaterThan(1);
+        farm.update(300000); // large delta to reach maturity
+        expect(farm.growthStage).toBe(3);
+    });
+
+    test('harvest returns crop only when mature', () => {
+        farm.plant('wheat');
+        expect(farm.harvest()).toBeNull();
+        farm.growthStage = 3;
+        expect(farm.harvest()).toBe('wheat');
+        expect(farm.crop).toBeNull();
+        expect(farm.growthStage).toBe(0);
+    });
+});

--- a/__tests__/SoundManager.test.js
+++ b/__tests__/SoundManager.test.js
@@ -17,16 +17,16 @@ describe('SoundManager', () => {
         global.Audio = jest.fn(() => audioMock);
     });
 
-    test('default volume is half', () => {
+    test('default volume is zero', () => {
         const sm = new SoundManager();
-        expect(sm.volume).toBe(0.5);
+        expect(sm.volume).toBe(0);
     });
 
     test('loadSound stores audio', async () => {
         const sm = new SoundManager();
         await sm.loadSound('test', 'url');
         expect(sm.sounds.test).toBe(audioMock);
-        expect(audioMock.volume).toBe(0.5);
+        expect(audioMock.volume).toBe(0);
     });
 
     test('setVolume updates volume and play uses it', async () => {

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -235,7 +235,7 @@ export default class Settler {
                     if (this.currentTask.quantity <= 0) {
                         this.carrying = { type: resourceType, quantity: 1 }; // Settler carries the resource
                         if (this.currentTask.type === "dig_dirt") {
-                            this.map.tiles[this.currentTask.targetY][this.currentTask.targetX] = 0; // Change tile to grass
+                            this.map.tiles[this.currentTask.targetY][this.currentTask.targetX] = 1; // Change tile to dirt
                         } else {
                             this.map.removeResourceNode(this.currentTask.targetX, this.currentTask.targetY);
                         }


### PR DESCRIPTION
## Summary
- adjust dig_dirt to convert grass into dirt
- update tests for event timing, sound volume and enemy damage parameters
- add new FarmPlot.test.js for planting and harvesting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884c851e6c0832381fab82ea6b19f98