### PR TITLE
Require hauling resources to construction

### DIFF
--- a/__tests__/Game.test.js
+++ b/__tests__/Game.test.js
@@ -123,7 +123,8 @@ describe('Game', () => {
             1,
             1,
             'wood',
-            0 // buildProgress starts at 0
+            0,
+            1
         );
         expect(game.taskManager.addTask).toHaveBeenCalledTimes(2);
         expect(Task).toHaveBeenCalledWith(
@@ -132,10 +133,10 @@ describe('Game', () => {
             expectedTileY,
             null,
             100,
-            3,
+            2,
             expect.any(Building)
         );
-        const haulTask = game.taskManager.addTask.mock.calls[1][0];
+        const haulTask = game.taskManager.addTask.mock.calls[0][0];
         expect(haulTask.type).toBe('haul');
         expect(haulTask.building).toBeInstanceOf(Building);
         expect(game.buildMode).toBe(false);

--- a/__tests__/Game.test.js
+++ b/__tests__/Game.test.js
@@ -125,7 +125,7 @@ describe('Game', () => {
             'wood',
             0 // buildProgress starts at 0
         );
-        expect(game.taskManager.addTask).toHaveBeenCalledTimes(1);
+        expect(game.taskManager.addTask).toHaveBeenCalledTimes(2);
         expect(Task).toHaveBeenCalledWith(
             'build',
             expectedTileX,
@@ -135,7 +135,9 @@ describe('Game', () => {
             3,
             expect.any(Building)
         );
-        expect(game.taskManager.addTask).toHaveBeenCalledTimes(1);
+        const haulTask = game.taskManager.addTask.mock.calls[1][0];
+        expect(haulTask.type).toBe('haul');
+        expect(haulTask.building).toBeInstanceOf(Building);
         expect(game.buildMode).toBe(false);
         expect(game.selectedBuilding).toBe(null);
     });

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -1,5 +1,5 @@
 export default class Building {
-    constructor(type, x, y, width, height, material, buildProgress) {
+    constructor(type, x, y, width, height, material, buildProgress, resourcesRequired = 10) {
         this.type = type; // e.g., "wall", "floor", "house"
         this.x = x;
         this.y = y;
@@ -9,6 +9,10 @@ export default class Building {
         this.buildProgress = buildProgress; // 0-100, 100 means built
         this.maxHealth = 100; // Max health for destruction
         this.health = this.maxHealth; // Current health
+
+        // New properties for resource delivery
+        this.resourcesRequired = resourcesRequired;
+        this.resourcesDelivered = 0;
     }
 
     takeDamage(amount) {
@@ -38,6 +42,8 @@ export default class Building {
             height: this.height,
             material: this.material,
             buildProgress: this.buildProgress,
+            resourcesRequired: this.resourcesRequired,
+            resourcesDelivered: this.resourcesDelivered,
             maxHealth: this.maxHealth,
             health: this.health
         };
@@ -51,6 +57,8 @@ export default class Building {
         this.height = data.height;
         this.material = data.material;
         this.buildProgress = data.buildProgress;
+        this.resourcesRequired = data.resourcesRequired ?? 10;
+        this.resourcesDelivered = data.resourcesDelivered ?? 0;
         this.maxHealth = data.maxHealth;
         this.health = data.health;
     }

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -155,6 +155,15 @@ export default class Game {
             if (typeof building.update === 'function') {
                 building.update(deltaTime * this.gameSpeed);
             }
+
+            // Ensure a build task exists for unfinished buildings
+            if (building.buildProgress < 100) {
+                const hasTask = this.taskManager.tasks.some(t => t.type === 'build' && t.building === building);
+                const inProgress = this.settlers.some(s => s.currentTask && s.currentTask.type === 'build' && s.currentTask.building === building);
+                if (!hasTask && !inProgress) {
+                    this.taskManager.addTask(new Task('build', building.x, building.y, null, 100, 2, building));
+                }
+            }
         });
 
         let resourceString = "";
@@ -421,13 +430,16 @@ export default class Game {
                 newBuilding = new Furniture('table', tileX, tileY, 2, 1, 'wood', 75);
             } else if (this.selectedBuilding === 'barricade') {
                 newBuilding = new Building('barricade', tileX, tileY, 1, 1, "wood", 0); // Barricade is a simple building
+            } else if (this.selectedBuilding === 'wall') {
+                newBuilding = new Building('wall', tileX, tileY, 1, 1, 'wood', 0, 1); // Walls require 1 wood
             } else {
                 newBuilding = new Building(this.selectedBuilding, tileX, tileY, 1, 1, "wood", 0); // Start with 0 health
             }
             this.map.addBuilding(newBuilding);
-            this.taskManager.addTask(new Task("build", tileX, tileY, null, 100, 3, newBuilding)); // Build task with 100 quantity (workload)
-            // Create a haul task to bring required materials to the new building
-            this.taskManager.addTask(new Task("haul", 0, 0, newBuilding.material, newBuilding.resourcesRequired, 2, newBuilding));
+            // Hauling should happen before building starts
+            this.taskManager.addTask(new Task("haul", 0, 0, newBuilding.material, newBuilding.resourcesRequired, 3, newBuilding));
+            // Build task has lower priority so it begins once resources arrive
+            this.taskManager.addTask(new Task("build", tileX, tileY, null, 100, 2, newBuilding));
             this.soundManager.play('action');
             this.buildMode = false; // Exit build mode after placing
             this.selectedBuilding = null;

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -426,6 +426,8 @@ export default class Game {
             }
             this.map.addBuilding(newBuilding);
             this.taskManager.addTask(new Task("build", tileX, tileY, null, 100, 3, newBuilding)); // Build task with 100 quantity (workload)
+            // Create a haul task to bring required materials to the new building
+            this.taskManager.addTask(new Task("haul", 0, 0, newBuilding.material, newBuilding.resourcesRequired, 2, newBuilding));
             this.soundManager.play('action');
             this.buildMode = false; // Exit build mode after placing
             this.selectedBuilding = null;

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -86,8 +86,9 @@ export default class Game {
         } catch (error) {
             console.error("Failed to load sprite:", error);
         }
-        this.resourceManager.addResource("wood", 100);
-        this.resourceManager.addResource("stone", 50);
+        // Place initial resource piles instead of using global inventory
+        this.map.addResourcePile(new ResourcePile('wood', 100, 2, 2, this.map.tileSize, this.spriteManager));
+        this.map.addResourcePile(new ResourcePile('stone', 50, 3, 2, this.map.tileSize, this.spriteManager));
 
         // Create a new settler
         this.settlers.push(new Settler("Alice", 5, 5, this.resourceManager, this.map, this.roomManager, this.spriteManager));

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -381,9 +381,10 @@ export default class Settler {
                             this.map.addResourcePile(newPile);
                         }
                         building.resourcesDelivered += this.carrying.quantity;
+                        const deliveredType = this.currentTask.resourceType;
                         this.carrying = null;
                         this.currentTask = null;
-                        console.log(`${this.name} delivered ${this.currentTask.resourceType} to building site.`);
+                        console.log(`${this.name} delivered ${deliveredType} to building site.`);
                     }
                 } else if (this.currentTask.type === "haul" && this.currentTask.resource) {
                     const room = this.roomManager.getRoomAt(this.currentTask.targetX, this.currentTask.targetY);

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -1,5 +1,6 @@
 
 import Task from './task.js';
+import ResourcePile from './resourcePile.js';
 
 export default class Settler {
     constructor(name, x, y, resourceManager, map, roomManager, spriteManager) {
@@ -152,19 +153,23 @@ export default class Settler {
             }
         }
 
-        // If hauling, find a storage room and set a task
+        // If hauling, deliver to construction site if possible, otherwise storage
         if (this.state === "hauling" && !this.currentTask) {
-            const storageRooms = this.roomManager.rooms.filter(room => room.type === "storage");
-            if (storageRooms.length > 0) {
-                // For simplicity, just pick the first storage room
-                const targetRoom = storageRooms[0];
-                // Find a tile within the storage room to drop off resources
-                const targetTile = targetRoom.tiles[0]; // Just use the first tile for now
-                this.currentTask = { type: "haul", targetX: targetTile.x, targetY: targetTile.y, resource: this.carrying };
-                console.log(`${this.name} is hauling ${this.carrying.type} to storage.`);
+            const targetBuilding = (this.map.buildings || []).find(b => b.buildProgress < 100 && b.material === this.carrying.type && b.resourcesDelivered < b.resourcesRequired);
+            if (targetBuilding) {
+                this.currentTask = { type: "haul", targetX: targetBuilding.x, targetY: targetBuilding.y, resource: this.carrying, building: targetBuilding };
+                console.log(`${this.name} is hauling ${this.carrying.type} to construction site.`);
             } else {
-                console.log(`${this.name} has resources to haul but no storage room found.`);
-                this.state = "idle"; // Go back to idle if no storage
+                const storageRooms = this.roomManager.rooms.filter(room => room.type === "storage");
+                if (storageRooms.length > 0) {
+                    const targetRoom = storageRooms[0];
+                    const targetTile = targetRoom.tiles[0];
+                    this.currentTask = { type: "haul", targetX: targetTile.x, targetY: targetTile.y, resource: this.carrying };
+                    console.log(`${this.name} is hauling ${this.carrying.type} to storage.`);
+                } else {
+                    console.log(`${this.name} has resources to haul but no storage room found.`);
+                    this.state = "idle"; // Go back to idle if no storage
+                }
             }
         }
 
@@ -192,30 +197,39 @@ export default class Settler {
                     console.log(`${this.name} completed task: ${this.currentTask.type}`);
                     this.currentTask = null;
                 } else if (this.currentTask.type === "build" && this.currentTask.building) {
-                    const material = this.currentTask.building.material;
-                    const consumptionRate = 0.1; // e.g., 0.1 units of material per second
-                    const amountToConsume = consumptionRate * (deltaTime / 1000); // Amount to consume per update
+                    const building = this.currentTask.building;
+                    const material = building.material;
+                    const consumptionRate = 0.1; // units of material per second
+                    const amountToConsume = consumptionRate * (deltaTime / 1000);
 
-                    if (material && this.resourceManager.removeResource(material, amountToConsume)) {
-                        const workAmount = 1 * (deltaTime / 1000); // Amount of work done
-                        this.currentTask.building.buildProgress += workAmount; // Increase build progress
-                        if (this.currentTask.building.buildProgress >= 100) {
-                            this.currentTask.building.buildProgress = 100;
-                            console.log(`${this.name} completed building task for ${this.currentTask.building.type}`);
-                            this.currentTask = null; // Task completed
-                        }
-                    } else if (!material) { // If no material is required, just build
-                        const workAmount = 1 * (deltaTime / 1000); // Amount of work done
-                        this.currentTask.building.buildProgress += workAmount; // Increase build progress
-                        if (this.currentTask.building.buildProgress >= 100) {
-                            this.currentTask.building.buildProgress = 100;
-                            console.log(`${this.name} completed building task for ${this.currentTask.building.type}`);
-                            this.currentTask = null; // Task completed
+                    if (building.resourcesDelivered < building.resourcesRequired) {
+                        const pile = this.map.resourcePiles.find(p => p.x === building.x && p.y === building.y && p.type === material);
+                        if (pile && pile.remove(amountToConsume)) {
+                            building.resourcesDelivered += amountToConsume;
+                            if (pile.quantity <= 0) {
+                                this.map.resourcePiles = this.map.resourcePiles.filter(p => p !== pile);
+                            }
+                        } else if (this.carrying && this.carrying.type === material) {
+                            const needed = building.resourcesRequired - building.resourcesDelivered;
+                            const amountToDrop = Math.min(needed, this.carrying.quantity);
+                            building.resourcesDelivered += amountToDrop;
+                            this.carrying.quantity -= amountToDrop;
+                            if (this.carrying.quantity <= 0) this.carrying = null;
+                        } else {
+                            console.log(`${this.name} needs ${material} delivered to build site.`);
+                            this.currentTask = null;
+                            return;
                         }
                     }
-                    else {
-                        console.log(`${this.name} stopped building due to lack of ${material}`);
-                        this.currentTask = null; // Clear the task
+
+                    if (building.resourcesDelivered >= building.resourcesRequired) {
+                        const workAmount = 1 * (deltaTime / 1000); // Amount of work done
+                        building.buildProgress += workAmount; // Increase build progress
+                        if (building.buildProgress >= 100) {
+                            building.buildProgress = 100;
+                            console.log(`${this.name} completed building task for ${building.type}`);
+                            this.currentTask = null; // Task completed
+                        }
                     }
                 } else if (this.currentTask.type === "craft" && this.currentTask.recipe) {
                     const recipe = this.currentTask.recipe;
@@ -327,15 +341,33 @@ export default class Settler {
                     }
                     this.currentTask = null;
                 } else if (this.currentTask.type === "haul" && this.currentTask.resource) {
-                    const room = this.roomManager.getRoomAt(this.currentTask.targetX, this.currentTask.targetY);
-                    if (room && room.type === "storage") {
-                        this.roomManager.addResourceToStorage(room, this.currentTask.resource.type, this.currentTask.resource.quantity);
-                        this.carrying = null; // Clear carried resource
-                        console.log(`${this.name} deposited ${this.currentTask.resource.type} into storage.`);
+                    if (this.currentTask.building) {
+                        const building = this.currentTask.building;
+                        if (building.material === this.currentTask.resource.type) {
+                            const existingPile = this.map.resourcePiles.find(p => p.x === building.x && p.y === building.y && p.type === this.currentTask.resource.type);
+                            if (existingPile) {
+                                existingPile.add(this.currentTask.resource.quantity);
+                            } else {
+                                const newPile = new ResourcePile(this.currentTask.resource.type, this.currentTask.resource.quantity, building.x, building.y, this.map.tileSize, this.spriteManager);
+                                this.map.addResourcePile(newPile);
+                            }
+                            this.carrying = null;
+                            console.log(`${this.name} delivered ${this.currentTask.resource.type} to building site.`);
+                        } else {
+                            console.log(`${this.name} cannot deliver ${this.currentTask.resource.type} to this building.`);
+                        }
+                        this.currentTask = null;
                     } else {
-                        console.log(`${this.name} arrived at haul destination but it's not a storage room.`);
+                        const room = this.roomManager.getRoomAt(this.currentTask.targetX, this.currentTask.targetY);
+                        if (room && room.type === "storage") {
+                            this.roomManager.addResourceToStorage(room, this.currentTask.resource.type, this.currentTask.resource.quantity);
+                            this.carrying = null; // Clear carried resource
+                            console.log(`${this.name} deposited ${this.currentTask.resource.type} into storage.`);
+                        } else {
+                            console.log(`${this.name} arrived at haul destination but it's not a storage room.`);
+                        }
+                        this.currentTask = null; // Task completed immediately after action
                     }
-                    this.currentTask = null; // Task completed immediately after action
                 } else if (this.currentTask.type === "explore" && this.currentTask.targetLocation) {
                     // Settler has arrived at the exploration target
                     this.map.worldMap.discoverLocation(this.currentTask.targetLocation.id);


### PR DESCRIPTION
## Summary
- track required resources per building
- move collected materials to construction sites
- consume piles or carried resources while building
- put starting wood and stone into resource piles

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6884e806822883238dd3f1586a8e3e1f