### PR TITLE
Implement resource drop when no storage

### DIFF
--- a/__tests__/Settler.test.js
+++ b/__tests__/Settler.test.js
@@ -20,6 +20,10 @@ describe('Settler', () => {
         };
         mockMap = {
             removeResourceNode: jest.fn(),
+            resourcePiles: [],
+            addResourcePile: jest.fn(function(pile) { this.resourcePiles.push(pile); }),
+            tileSize: 1,
+            buildings: []
         };
         mockRoomManager = {
             rooms: [],
@@ -311,7 +315,23 @@ describe('Settler', () => {
 
         expect(mockEnemy.isButchered).toBe(true);
         expect(mockEnemy.isMarkedForButcher).toBe(false);
-        expect(settler.carrying.type).toBe('meat');
+        expect(settler.map.addResourcePile).toHaveBeenCalled();
+        expect(settler.carrying).toBe(null);
         expect(settler.currentTask).toBe(null);
+    });
+
+    test('should drop carried resource if no storage room found', () => {
+        settler.roomManager.rooms = [];
+        settler.carrying = { type: 'wood', quantity: 2 };
+        settler.x = 0;
+        settler.y = 0;
+
+        settler.updateNeeds(1000);
+
+        expect(settler.map.addResourcePile).toHaveBeenCalled();
+        const droppedPile = settler.map.addResourcePile.mock.calls[0][0];
+        expect(droppedPile.type).toBe('wood');
+        expect(droppedPile.quantity).toBe(2);
+        expect(settler.carrying).toBe(null);
     });
 });

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -167,8 +167,18 @@ export default class Settler {
                     this.currentTask = { type: "haul", targetX: targetTile.x, targetY: targetTile.y, resource: this.carrying };
                     console.log(`${this.name} is hauling ${this.carrying.type} to storage.`);
                 } else {
-                    console.log(`${this.name} has resources to haul but no storage room found.`);
-                    this.state = "idle"; // Go back to idle if no storage
+                    console.log(`${this.name} has resources to haul but no storage room found. Dropping on the ground.`);
+                    const dropX = Math.floor(this.x);
+                    const dropY = Math.floor(this.y);
+                    const existingPile = this.map.resourcePiles.find(p => p.x === dropX && p.y === dropY && p.type === this.carrying.type);
+                    if (existingPile) {
+                        existingPile.add(this.carrying.quantity);
+                    } else {
+                        const newPile = new ResourcePile(this.carrying.type, this.carrying.quantity, dropX, dropY, this.map.tileSize, this.spriteManager);
+                        this.map.addResourcePile(newPile);
+                    }
+                    this.carrying = null;
+                    this.state = "idle"; // Go back to idle after dropping
                 }
             }
         }


### PR DESCRIPTION
## Summary
- improve settler hauling logic so gathered items are dropped if there is no storage
- cover new behavior with tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6884f2c41cd48323932989343f944137