### PR TITLE
Fix boar butchering reward

### DIFF
--- a/src/js/enemy.js
+++ b/src/js/enemy.js
@@ -4,7 +4,7 @@ import Settler from './settler.js';
 let enemyIdCounter = 0;
 
 export default class Enemy {
-    constructor(name, x, y, targetSettler, spriteManager) {
+    constructor(name, x, y, targetSettler, spriteManager, lootType = 'meat') {
         this.id = enemyIdCounter++;
         this.name = name;
         this.x = x;
@@ -16,6 +16,7 @@ export default class Enemy {
         this.targetSettler = targetSettler; // The settler this enemy is targeting
         this.state = "attacking"; // For now, always attacking
         this.spriteManager = spriteManager;
+        this.lootType = lootType; // Resource type yielded when butchered
         this.isDead = false; // New property to track if the enemy is dead
         this.isButchered = false; // True when the enemy has been butchered
         this.isMarkedForButcher = false; // True when player has queued this enemy for butchering
@@ -130,7 +131,8 @@ export default class Enemy {
             id: this.id,
             isDead: this.isDead,
             isButchered: this.isButchered,
-            isMarkedForButcher: this.isMarkedForButcher
+            isMarkedForButcher: this.isMarkedForButcher,
+            lootType: this.lootType
         };
     }
 
@@ -147,5 +149,6 @@ export default class Enemy {
         this.isDead = data.isDead || false;
         this.isButchered = data.isButchered || false;
         this.isMarkedForButcher = data.isMarkedForButcher || false;
+        this.lootType = data.lootType || 'meat';
     }
 }

--- a/src/js/eventManager.js
+++ b/src/js/eventManager.js
@@ -22,7 +22,7 @@ export default class EventManager {
                     // Spawn a new enemy
                     if (this.game.settlers.length > 0) {
                         const targetSettler = this.game.settlers[Math.floor(Math.random() * this.game.settlers.length)];
-                        this.game.enemies.push(new this.EnemyClass("Wild Boar", 49, 29, targetSettler, this.game.spriteManager));
+                        this.game.enemies.push(new this.EnemyClass("Wild Boar", 49, 29, targetSettler, this.game.spriteManager, 'meat'));
                         console.log("A wild boar has appeared!");
                     this.game.notificationManager.addNotification("A wild boar has appeared!", 'warning');
                     }

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -300,7 +300,8 @@ export default class Settler {
                     this.currentTask.quantity -= amountToButcher;
 
                     if (this.currentTask.quantity <= 0) {
-                        this.carrying = { type: 'meat', quantity: 1 };
+                        const lootType = this.currentTask.targetEnemy.lootType || 'meat';
+                        this.carrying = { type: lootType, quantity: 1 };
                         this.currentTask.targetEnemy.isButchered = true;
                         this.currentTask.targetEnemy.isMarkedForButcher = false;
                         console.log(`${this.name} butchered ${this.currentTask.targetEnemy.name}.`);


### PR DESCRIPTION
## Summary
- add a `lootType` property for Enemy instances
- use `lootType` in Settler butchering logic
- spawn wild boars with `lootType` set to `meat`
- set default enemy loot type to `meat`

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6884f2e2353483238f819766921c1e06