### PR TITLE
Limit storage piles to one per tile

### DIFF
--- a/__tests__/Map.test.js
+++ b/__tests__/Map.test.js
@@ -1,0 +1,23 @@
+import Map from '../src/js/map.js';
+import ResourcePile from '../src/js/resourcePile.js';
+
+describe('Map resource piles', () => {
+    test('should not allow multiple piles on same tile', () => {
+        const map = new Map(10, 10, 32, { getSprite: jest.fn() });
+        const pile1 = new ResourcePile('wood', 10, 1, 1, 32, {});
+        const pile2 = new ResourcePile('stone', 5, 1, 1, 32, {});
+        expect(map.addResourcePile(pile1)).toBe(true);
+        expect(map.addResourcePile(pile2)).toBe(false);
+        expect(map.resourcePiles.length).toBe(1);
+    });
+
+    test('should merge piles of same type on same tile', () => {
+        const map = new Map(10, 10, 32, { getSprite: jest.fn() });
+        const pile1 = new ResourcePile('wood', 10, 2, 2, 32, {});
+        const pile2 = new ResourcePile('wood', 5, 2, 2, 32, {});
+        map.addResourcePile(pile1);
+        map.addResourcePile(pile2);
+        expect(map.resourcePiles.length).toBe(1);
+        expect(map.resourcePiles[0].quantity).toBe(15);
+    });
+});

--- a/__tests__/ResourcePile.test.js
+++ b/__tests__/ResourcePile.test.js
@@ -1,0 +1,14 @@
+import ResourcePile from '../src/js/resourcePile.js';
+
+describe('ResourcePile', () => {
+    test('should cap quantity at 999 when adding', () => {
+        const pile = new ResourcePile('wood', 990, 0, 0, 32, {});
+        pile.add(20);
+        expect(pile.quantity).toBe(999);
+    });
+
+    test('constructor should not exceed max quantity', () => {
+        const pile = new ResourcePile('stone', 1200, 0, 0, 32, {});
+        expect(pile.quantity).toBe(999);
+    });
+});

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -56,7 +56,18 @@ export default class Map {
 
     addResourcePile(resourcePile) {
         resourcePile.spriteManager = this.spriteManager; // Assign spriteManager to the resource pile
-        this.resourcePiles.push(resourcePile);
+        const existing = this.resourcePiles.find(p => p.x === resourcePile.x && p.y === resourcePile.y);
+        if (existing) {
+            if (existing.type === resourcePile.type) {
+                existing.add(resourcePile.quantity);
+            } else {
+                console.warn(`Tile ${resourcePile.x},${resourcePile.y} already has a pile.`);
+                return false;
+            }
+        } else {
+            this.resourcePiles.push(resourcePile);
+        }
+        return true;
     }
 
     addBuilding(building) {

--- a/src/js/resourcePile.js
+++ b/src/js/resourcePile.js
@@ -2,12 +2,18 @@
 import Resource from './resource.js';
 
 export default class ResourcePile extends Resource {
+    static MAX_QUANTITY = 999;
+
     constructor(type, quantity, x, y, tileSize, spriteManager, quality = 1) {
-        super(type, quantity, quality);
+        super(type, Math.min(quantity, ResourcePile.MAX_QUANTITY), quality);
         this.x = x;
         this.y = y;
         this.tileSize = tileSize;
         this.spriteManager = spriteManager;
+    }
+
+    add(amount) {
+        this.quantity = Math.min(this.quantity + amount, ResourcePile.MAX_QUANTITY);
     }
 
     render(ctx) {
@@ -48,7 +54,7 @@ export default class ResourcePile extends Resource {
 
     deserialize(data) {
         this.type = data.type;
-        this.quantity = data.quantity;
+        this.quantity = Math.min(data.quantity, ResourcePile.MAX_QUANTITY);
         this.quality = data.quality;
         this.x = data.x;
         this.y = data.y;

--- a/src/js/roomManager.js
+++ b/src/js/roomManager.js
@@ -68,16 +68,29 @@ export default class RoomManager {
             room.storage[resourceType] += quantity;
             console.log(`Added ${quantity} ${resourceType} to storage room ${room.id}. Current: ${room.storage[resourceType]}`);
             
-            // Find a suitable tile in the storage room to place the resource pile
             if (room.tiles.length > 0) {
-                const { x, y } = room.tiles[0]; // Use the first tile of the room for now
-                const existingPile = this.map.resourcePiles.find(pile => pile.x === x && pile.y === y && pile.type === resourceType);
+                let emptyTile = null;
+                let pile = null;
 
-                if (existingPile) {
-                    existingPile.add(quantity);
-                } else {
-                    const newPile = new ResourcePile(resourceType, quantity, x, y, this.tileSize, this.spriteManager);
+                for (const tile of room.tiles) {
+                    const pileAtTile = this.map.resourcePiles.find(p => p.x === tile.x && p.y === tile.y);
+                    if (pileAtTile) {
+                        if (pileAtTile.type === resourceType) {
+                            pile = pileAtTile;
+                            break;
+                        }
+                    } else if (!emptyTile) {
+                        emptyTile = tile;
+                    }
+                }
+
+                if (pile) {
+                    pile.add(quantity);
+                } else if (emptyTile) {
+                    const newPile = new ResourcePile(resourceType, quantity, emptyTile.x, emptyTile.y, this.tileSize, this.spriteManager);
                     this.map.addResourcePile(newPile);
+                } else {
+                    console.warn('No available storage tile for resource pile.');
                 }
             }
             return true;


### PR DESCRIPTION
## Summary
- cap `ResourcePile` size at 999
- merge piles when dropped on the same tile and prevent different-type piles from stacking
- allocate storage piles across available room tiles
- test resource pile limits and map pile behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884f5e30b3883238b29893105a44ab6