### PR TITLE
Implement corpse decay mechanic

### DIFF
--- a/__tests__/Game.test.js
+++ b/__tests__/Game.test.js
@@ -221,7 +221,7 @@ describe('Game', () => {
         game.map.tileSize = 32;
         const tileX = Math.floor(((100 - mockCtx.canvas.width / 2) / game.camera.zoom + game.camera.x) / game.map.tileSize);
         const tileY = Math.floor(((100 - mockCtx.canvas.height / 2) / game.camera.zoom + game.camera.y) / game.map.tileSize);
-        const enemy = { x: tileX, y: tileY, isDead: true, isMarkedForButcher: false, isButchered: false };
+        const enemy = { x: tileX, y: tileY, isDead: true, decay: 0, isMarkedForButcher: false, isButchered: false };
         game.enemies = [enemy];
 
         game.handleClick({ clientX: 100, clientY: 100, target: { closest: () => null } });
@@ -231,6 +231,19 @@ describe('Game', () => {
         const addedTask = game.taskManager.addTask.mock.calls[0][0];
         expect(addedTask.type).toBe('butcher');
         expect(addedTask.targetEnemy).toBe(enemy);
+    });
+
+    test('handleClick does not mark heavily decayed enemy for butchering', () => {
+        game.map.tileSize = 32;
+        const tileX = Math.floor(((100 - mockCtx.canvas.width / 2) / game.camera.zoom + game.camera.x) / game.map.tileSize);
+        const tileY = Math.floor(((100 - mockCtx.canvas.height / 2) / game.camera.zoom + game.camera.y) / game.map.tileSize);
+        const enemy = { x: tileX, y: tileY, isDead: true, decay: 60, isMarkedForButcher: false, isButchered: false };
+        game.enemies = [enemy];
+
+        game.handleClick({ clientX: 100, clientY: 100, target: { closest: () => null } });
+
+        expect(enemy.isMarkedForButcher).toBe(false);
+        expect(game.taskManager.addTask).not.toHaveBeenCalled();
     });
 
     test('setSoundVolume updates SoundManager volume', () => {

--- a/__tests__/Settler.test.js
+++ b/__tests__/Settler.test.js
@@ -320,6 +320,23 @@ describe('Settler', () => {
         expect(settler.currentTask).toBe(null);
     });
 
+    test('should not butcher enemy decayed over 50%', () => {
+        const mockEnemy = { id: 2, name: 'Goblin', decay: 60, isButchered: false, isMarkedForButcher: true };
+        const task = new Task('butcher', 0, 0, 'meat', 0.2, 2, null, null, null, null, null, null, mockEnemy);
+        settler.currentTask = task;
+        settler.x = 0;
+        settler.y = 0;
+
+        for (let i = 0; i < 10; i++) {
+            settler.updateNeeds(1000);
+        }
+
+        expect(mockEnemy.isButchered).toBe(false);
+        expect(mockEnemy.isMarkedForButcher).toBe(false);
+        expect(settler.carrying).toBe(null);
+        expect(settler.currentTask).toBe(null);
+    });
+
     test('should drop carried resource if no storage room found', () => {
         settler.roomManager.rooms = [];
         settler.carrying = { type: 'wood', quantity: 2 };

--- a/src/js/enemy.js
+++ b/src/js/enemy.js
@@ -17,13 +17,19 @@ export default class Enemy {
         this.state = "attacking"; // For now, always attacking
         this.spriteManager = spriteManager;
         this.lootType = lootType; // Resource type yielded when butchered
-        this.isDead = false; // New property to track if the enemy is dead
+        this.isDead = false; // True when the enemy has been killed
         this.isButchered = false; // True when the enemy has been butchered
         this.isMarkedForButcher = false; // True when player has queued this enemy for butchering
+        this.decay = 0; // 0-100 percentage of decay
+        this.decayRate = 0.01; // percent per second
     }
 
     update(deltaTime, settlers) {
-        if (this.isDead) return; // Do nothing if dead
+        if (this.isDead) {
+            this.decay += this.decayRate * (deltaTime / 1000);
+            if (this.decay > 100) this.decay = 100;
+            return; // No actions when dead
+        }
         this.attackCooldown -= deltaTime / 1000;
 
         if (this.targetSettler) {
@@ -132,7 +138,8 @@ export default class Enemy {
             isDead: this.isDead,
             isButchered: this.isButchered,
             isMarkedForButcher: this.isMarkedForButcher,
-            lootType: this.lootType
+            lootType: this.lootType,
+            decay: this.decay
         };
     }
 
@@ -150,5 +157,6 @@ export default class Enemy {
         this.isButchered = data.isButchered || false;
         this.isMarkedForButcher = data.isMarkedForButcher || false;
         this.lootType = data.lootType || 'meat';
+        this.decay = data.decay || 0;
     }
 }

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -488,7 +488,7 @@ export default class Game {
                 }
             } else {
                 const clickedEnemy = this.enemies.find(e => Math.floor(e.x) === tileX && Math.floor(e.y) === tileY);
-                if (clickedEnemy && clickedEnemy.isDead && !clickedEnemy.isMarkedForButcher && !clickedEnemy.isButchered) {
+                if (clickedEnemy && clickedEnemy.isDead && clickedEnemy.decay <= 50 && !clickedEnemy.isMarkedForButcher && !clickedEnemy.isButchered) {
                     this.taskManager.addTask(new Task("butcher", tileX, tileY, "meat", 1, 2, null, null, null, null, null, null, clickedEnemy));
                     clickedEnemy.isMarkedForButcher = true;
                     console.log(`Butcher task added at ${tileX},${tileY}`);

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -305,17 +305,23 @@ export default class Settler {
                         this.currentTask = null;
                     }
                 } else if (this.currentTask.type === "butcher" && this.currentTask.targetEnemy) {
-                    const butcheringRate = 0.1;
-                    const amountToButcher = butcheringRate * (deltaTime / 1000);
-                    this.currentTask.quantity -= amountToButcher;
-
-                    if (this.currentTask.quantity <= 0) {
-                        const lootType = this.currentTask.targetEnemy.lootType || 'meat';
-                        this.carrying = { type: lootType, quantity: 1 };
-                        this.currentTask.targetEnemy.isButchered = true;
+                    if (this.currentTask.targetEnemy.decay > 50) {
                         this.currentTask.targetEnemy.isMarkedForButcher = false;
-                        console.log(`${this.name} butchered ${this.currentTask.targetEnemy.name}.`);
+                        console.log(`${this.currentTask.targetEnemy.name} is too decayed to butcher.`);
                         this.currentTask = null;
+                    } else {
+                        const butcheringRate = 0.1;
+                        const amountToButcher = butcheringRate * (deltaTime / 1000);
+                        this.currentTask.quantity -= amountToButcher;
+
+                        if (this.currentTask.quantity <= 0) {
+                            const lootType = this.currentTask.targetEnemy.lootType || 'meat';
+                            this.carrying = { type: lootType, quantity: 1 };
+                            this.currentTask.targetEnemy.isButchered = true;
+                            this.currentTask.targetEnemy.isMarkedForButcher = false;
+                            console.log(`${this.name} butchered ${this.currentTask.targetEnemy.name}.`);
+                            this.currentTask = null;
+                        }
                     }
                 } else if (this.currentTask.type === "sow_crop" && this.currentTask.building) {
                     const farmPlot = this.currentTask.building;


### PR DESCRIPTION
## Summary
- add decay progression to enemies and prevent butchering decayed corpses
- block butcher tasks for corpses beyond 50% decay
- ignore heavily decayed corpses when selecting them
- test new decay behavior for settlers and game

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884f89bd3648323a9cb4d1f5d0184f9