### PR TITLE
Implement hauling tasks assignment

### DIFF
--- a/__tests__/RoomManager.test.js
+++ b/__tests__/RoomManager.test.js
@@ -32,5 +32,9 @@ describe('RoomManager storage rules', () => {
 
         expect(taskManager.tasks.length).toBe(1);
         expect(taskManager.tasks[0].type).toBe('haul');
+        expect(taskManager.tasks[0].sourceX).toBe(2);
+        expect(taskManager.tasks[0].sourceY).toBe(2);
+        expect(taskManager.tasks[0].targetX).toBe(2); // initial target is pile
+        expect(taskManager.tasks[0].targetY).toBe(2);
     });
 });

--- a/__tests__/RoomManager.test.js
+++ b/__tests__/RoomManager.test.js
@@ -1,11 +1,13 @@
 import Map from '../src/js/map.js';
 import RoomManager from '../src/js/roomManager.js';
 import ResourcePile from '../src/js/resourcePile.js';
+import TaskManager from '../src/js/taskManager.js';
 
 describe('RoomManager storage rules', () => {
     test('should not allow multiple piles on the same storage tile', () => {
         const map = new Map(5, 5, 32, { getSprite: jest.fn() });
-        const roomManager = new RoomManager(map, { getSprite: jest.fn() }, 32);
+        const taskManager = new TaskManager();
+        const roomManager = new RoomManager(map, { getSprite: jest.fn() }, 32, taskManager);
         const room = roomManager.designateRoom(0, 0, 0, 0, 'storage');
         expect(room).not.toBeNull();
 
@@ -17,5 +19,18 @@ describe('RoomManager storage rules', () => {
         expect(roomManager.addResourceToStorage(room, 'stone', 5)).toBe(false);
         expect(map.resourcePiles.length).toBe(1);
         expect(map.resourcePiles[0].type).toBe('wood');
+    });
+
+    test('designating storage creates haul tasks for existing piles', () => {
+        const map = new Map(5, 5, 32, { getSprite: jest.fn() });
+        const taskManager = new TaskManager();
+        const roomManager = new RoomManager(map, { getSprite: jest.fn() }, 32, taskManager);
+
+        map.addResourcePile(new ResourcePile('wood', 5, 2, 2, 32, { getSprite: jest.fn() }));
+
+        roomManager.designateRoom(3, 3, 3, 3, 'storage');
+
+        expect(taskManager.tasks.length).toBe(1);
+        expect(taskManager.tasks[0].type).toBe('haul');
     });
 });

--- a/__tests__/Settler.test.js
+++ b/__tests__/Settler.test.js
@@ -1,5 +1,6 @@
 import Settler from '../src/js/settler.js';
 import Task from '../src/js/task.js';
+import ResourcePile from '../src/js/resourcePile.js';
 
 jest.mock('../src/js/resourceManager.js');
 jest.mock('../src/js/map.js');
@@ -283,6 +284,30 @@ describe('Settler', () => {
         settler.updateNeeds(1000); // Simulate enough time for task to complete
         expect(mockRoomManager.getRoomAt).toHaveBeenCalledWith(1, 1);
         expect(mockRoomManager.addResourceToStorage).toHaveBeenCalledWith({ type: 'storage' }, 'wood', 1);
+        expect(settler.carrying).toBe(null);
+        expect(settler.currentTask).toBe(null);
+    });
+
+    test('should haul pile from ground to storage', () => {
+        mockMap.resourcePiles.push(new ResourcePile('wood', 1, 0, 0, 1, { getSprite: jest.fn() }));
+        mockRoomManager.findStorageRoomAndTile.mockReturnValue({ room: { type: 'storage', tiles: [{ x: 1, y: 1 }], storage: {} }, tile: { x: 1, y: 1 } });
+        mockRoomManager.getRoomAt.mockReturnValue({ type: 'storage', tiles: [{ x: 1, y: 1 }], storage: {} });
+        mockRoomManager.addResourceToStorage.mockReturnValue(true);
+
+        const task = new Task('haul', 0, 0, 'wood', 1, 2, null, null, null, null, null, null, null, 0, 0);
+        settler.currentTask = task;
+        settler.x = 0;
+        settler.y = 0;
+
+        settler.updateNeeds(1000); // pick up pile
+        expect(settler.carrying).toEqual({ type: 'wood', quantity: 1 });
+        expect(settler.currentTask.targetX).toBe(1);
+        expect(settler.currentTask.targetY).toBe(1);
+
+        settler.x = 1;
+        settler.y = 1;
+        settler.updateNeeds(1000); // deposit
+        expect(mockRoomManager.addResourceToStorage).toHaveBeenCalled();
         expect(settler.carrying).toBe(null);
         expect(settler.currentTask).toBe(null);
     });

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -36,7 +36,7 @@ export default class Game {
         this.ui.setGameInstance(this);
         this.resourceManager = new ResourceManager();
         this.taskManager = new TaskManager();
-        this.roomManager = new RoomManager(this.map, this.spriteManager, this.map.tileSize);
+        this.roomManager = new RoomManager(this.map, this.spriteManager, this.map.tileSize, this.taskManager);
         this.worldMap = new WorldMap();
         this.factions = {
             bandits: new Faction('Bandits', -50),

--- a/src/js/roomManager.js
+++ b/src/js/roomManager.js
@@ -146,7 +146,9 @@ export default class RoomManager {
                 return false;
             }
         }
-
+        if (this.taskManager) {
+            this.assignHaulingTasksForDroppedPiles();
+        }
         return true;
     }
 

--- a/src/js/roomManager.js
+++ b/src/js/roomManager.js
@@ -177,8 +177,7 @@ export default class RoomManager {
             );
             if (!existing) {
                 const task = new Task('haul', pile.x, pile.y, pile.type, pile.quantity, 2, null, null, null, null, null, null, null, pile.x, pile.y);
-                task.targetX = target.tile.x;
-                task.targetY = target.tile.y;
+                // Initial target is the pile itself; destination will be chosen when picked up
                 this.taskManager.addTask(task);
             }
         }

--- a/src/js/roomManager.js
+++ b/src/js/roomManager.js
@@ -1,11 +1,13 @@
 import ResourcePile from './resourcePile.js';
+import Task from './task.js';
 
 export default class RoomManager {
-    constructor(map, spriteManager, tileSize) {
+    constructor(map, spriteManager, tileSize, taskManager = null) {
         this.map = map;
         this.spriteManager = spriteManager;
         this.tileSize = tileSize;
         this.map = map;
+        this.taskManager = taskManager;
         this.rooms = []; // Stores room objects
         this.roomGrid = Array(map.height).fill(0).map(() => Array(map.width).fill(null)); // 2D array to store room references for each tile
     }
@@ -48,6 +50,9 @@ export default class RoomManager {
         if (newRoom.tiles.length > 0) {
             this.rooms.push(newRoom);
             console.log(`Designated a ${type} room with ${newRoom.tiles.length} tiles.`);
+            if (type === 'storage' && this.taskManager) {
+                this.assignHaulingTasksForDroppedPiles();
+            }
             return newRoom;
         }
         return null;
@@ -150,6 +155,9 @@ export default class RoomManager {
             if (room.storage[resourceType] && room.storage[resourceType] >= quantity) {
                 room.storage[resourceType] -= quantity;
                 console.log(`Removed ${quantity} ${resourceType} from storage room ${room.id}. Current: ${room.storage[resourceType]}`);
+                if (this.taskManager) {
+                    this.assignHaulingTasksForDroppedPiles();
+                }
                 return true;
             }
             console.warn(`Not enough ${resourceType} in storage room ${room.id}.`);
@@ -157,6 +165,23 @@ export default class RoomManager {
         }
         console.warn(`Room ${room.id} is not a storage room.`);
         return false;
+    }
+
+    assignHaulingTasksForDroppedPiles() {
+        if (!this.taskManager) return;
+        for (const pile of this.map.resourcePiles) {
+            const target = this.findStorageRoomAndTile(pile.type);
+            if (!target) continue;
+            const existing = this.taskManager.tasks.some(
+                t => t.type === 'haul' && t.sourceX === pile.x && t.sourceY === pile.y && t.resourceType === pile.type
+            );
+            if (!existing) {
+                const task = new Task('haul', pile.x, pile.y, pile.type, pile.quantity, 2, null, null, null, null, null, null, null, pile.x, pile.y);
+                task.targetX = target.tile.x;
+                task.targetY = target.tile.y;
+                this.taskManager.addTask(task);
+            }
+        }
     }
 
     // Future: removeRoom, getRoomsByType, etc.

--- a/src/js/roomManager.js
+++ b/src/js/roomManager.js
@@ -146,9 +146,7 @@ export default class RoomManager {
                 return false;
             }
         }
-        if (this.taskManager) {
-            this.assignHaulingTasksForDroppedPiles();
-        }
+
         return true;
     }
 

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -401,6 +401,21 @@ export default class Settler {
                         this.currentTask = null;
                         console.log(`${this.name} delivered ${deliveredType} to building site.`);
                     }
+                } else if (this.currentTask.type === "haul" && this.currentTask.sourceX !== undefined && !this.currentTask.building && !this.currentTask.resource) {
+                    if (this.x === this.currentTask.sourceX && this.y === this.currentTask.sourceY) {
+                        const pile = this.map.resourcePiles.find(p => p.x === this.currentTask.sourceX && p.y === this.currentTask.sourceY && p.type === this.currentTask.resourceType);
+                        if (pile && pile.remove(this.currentTask.quantity)) {
+                            if (pile.quantity <= 0) {
+                                this.map.resourcePiles = this.map.resourcePiles.filter(p => p !== pile);
+                            }
+                            this.carrying = { type: this.currentTask.resourceType, quantity: this.currentTask.quantity };
+                            this.currentTask.resource = this.carrying;
+                            // targetX/Y already set to storage tile
+                        } else {
+                            console.log(`${this.name} failed to pick up ${this.currentTask.resourceType}.`);
+                            this.currentTask = null;
+                        }
+                    }
                 } else if (this.currentTask.type === "haul" && this.currentTask.resource) {
                     const room = this.roomManager.getRoomAt(this.currentTask.targetX, this.currentTask.targetY);
                     if (room && room.type === "storage") {

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -410,7 +410,14 @@ export default class Settler {
                             }
                             this.carrying = { type: this.currentTask.resourceType, quantity: this.currentTask.quantity };
                             this.currentTask.resource = this.carrying;
-                            // targetX/Y already set to storage tile
+                            const target = this.roomManager.findStorageRoomAndTile(this.currentTask.resourceType);
+                            if (target) {
+                                this.currentTask.targetX = target.tile.x;
+                                this.currentTask.targetY = target.tile.y;
+                            } else {
+                                console.log(`${this.name} couldn't find storage for ${this.currentTask.resourceType}.`);
+                                this.currentTask = null;
+                            }
                         } else {
                             console.log(`${this.name} failed to pick up ${this.currentTask.resourceType}.`);
                             this.currentTask = null;

--- a/src/js/task.js
+++ b/src/js/task.js
@@ -1,5 +1,5 @@
 export default class Task {
-    constructor(type, targetX, targetY, resourceType = null, quantity = 0, priority = 1, building = null, recipe = null, cropType = null, targetLocation = null, carrying = null, targetSettler = null, targetEnemy = null) {
+    constructor(type, targetX, targetY, resourceType = null, quantity = 0, priority = 1, building = null, recipe = null, cropType = null, targetLocation = null, carrying = null, targetSettler = null, targetEnemy = null, sourceX = null, sourceY = null) {
         this.type = type; // e.g., "chop_wood", "mine_stone", "eat", "sleep", "build", "craft", "mine_stone", "mine_iron_ore", "gather_berries", "mine_stone", "mine_iron_ore", "gather_berries", "treatment", "dig_dirt"
         this.targetX = targetX;
         this.targetY = targetY;
@@ -15,6 +15,8 @@ export default class Task {
         this.carrying = carrying; // For haul tasks
         this.targetSettler = targetSettler; // For treatment tasks
         this.targetEnemy = targetEnemy; // For butcher tasks
+        this.sourceX = sourceX; // For haul tasks from a source tile
+        this.sourceY = sourceY; // For haul tasks from a source tile
     }
 
     serialize() {
@@ -34,6 +36,8 @@ export default class Task {
             carrying: this.carrying,
             targetSettler: this.targetSettler ? this.targetSettler.name : null,
             targetEnemy: this.targetEnemy ? { id: this.targetEnemy.id } : null,
+            sourceX: this.sourceX,
+            sourceY: this.sourceY,
         };
     }
 
@@ -54,5 +58,7 @@ export default class Task {
         this.carrying = data.carrying;
         this.targetSettler = data.targetSettler; // Store raw data for now
         this.targetEnemy = data.targetEnemy; // Store raw data for now
+        this.sourceX = data.sourceX;
+        this.sourceY = data.sourceY;
     }
 }

--- a/src/js/taskManager.js
+++ b/src/js/taskManager.js
@@ -55,7 +55,9 @@ export default class TaskManager {
                 taskData.targetLocation,
                 taskData.carrying,
                 taskData.targetSettler,
-                taskData.targetEnemy
+                taskData.targetEnemy,
+                taskData.sourceX,
+                taskData.sourceY
             );
             task.deserialize(taskData);
             return task;


### PR DESCRIPTION
## Summary
- add source coordinates to Task to support hauling from ground
- allow RoomManager to schedule haul tasks when storage is designated or resources are removed
- pass TaskManager to RoomManager via Game constructor
- teach settlers to pick up piles for haul tasks
- test haul task creation when storage is designated

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688500c93d1483238c22c7903b5bbfea