### PR TITLE
Add bandage reward for hunt task

### DIFF
--- a/__tests__/Settler.test.js
+++ b/__tests__/Settler.test.js
@@ -254,7 +254,7 @@ describe('Settler', () => {
         expect(settler.currentTask).toBe(null);
     });
 
-    test('should handle hunt_animal task and give bandage', () => {
+    test('should handle hunt_animal task and drop bandage pile', () => {
         const task = new Task('hunt_animal', 1, 1, 'meat', 0.2);
         settler.currentTask = task;
         settler.x = 1;
@@ -265,8 +265,11 @@ describe('Settler', () => {
             settler.updateNeeds(1000);
         }
 
-        expect(mockResourceManager.addResource).toHaveBeenCalledWith('bandage', 1);
+        expect(mockResourceManager.addResource).not.toHaveBeenCalled();
         expect(settler.map.addResourcePile).toHaveBeenCalled();
+        const bandagePile = settler.map.addResourcePile.mock.calls[0][0];
+        expect(bandagePile.type).toBe('bandage');
+        expect(bandagePile.quantity).toBe(1);
         expect(settler.carrying).toBe(null);
         expect(settler.currentTask).toBe(null);
     });

--- a/__tests__/Settler.test.js
+++ b/__tests__/Settler.test.js
@@ -254,6 +254,23 @@ describe('Settler', () => {
         expect(settler.currentTask).toBe(null);
     });
 
+    test('should handle hunt_animal task and give bandage', () => {
+        const task = new Task('hunt_animal', 1, 1, 'meat', 0.2);
+        settler.currentTask = task;
+        settler.x = 1;
+        settler.y = 1;
+        settler.map.removeResourceNode = jest.fn();
+
+        for (let i = 0; i < 5; i++) {
+            settler.updateNeeds(1000);
+        }
+
+        expect(mockResourceManager.addResource).toHaveBeenCalledWith('bandage', 1);
+        expect(settler.map.addResourcePile).toHaveBeenCalled();
+        expect(settler.carrying).toBe(null);
+        expect(settler.currentTask).toBe(null);
+    });
+
     test('should handle explore task', () => {
         const mockLocation = { id: 'forest_outpost', name: 'Forest Outpost' };
         settler.map.worldMap = { discoverLocation: jest.fn() }; // Mock worldMap

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -299,8 +299,9 @@ export default class Settler {
                     if (this.currentTask.quantity <= 0) {
                         this.carrying = { type: resourceType, quantity: 1 }; // Settler carries the resource
                         if (this.currentTask.type === "hunt_animal") {
-                            // Hunting yields extra materials like bandages
-                            this.resourceManager.addResource('bandage', 1);
+                            // Hunting yields extra materials like bandages dropped on the ground
+                            const bandagePile = new ResourcePile('bandage', 1, this.currentTask.targetX, this.currentTask.targetY, this.map.tileSize, this.spriteManager);
+                            this.map.addResourcePile(bandagePile);
                         }
                         this.map.removeResourceNode(this.currentTask.targetX, this.currentTask.targetY);
                         console.log(`${this.name} completed ${this.currentTask.type} and is now carrying ${this.carrying.type}.`);

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -298,6 +298,10 @@ export default class Settler {
 
                     if (this.currentTask.quantity <= 0) {
                         this.carrying = { type: resourceType, quantity: 1 }; // Settler carries the resource
+                        if (this.currentTask.type === "hunt_animal") {
+                            // Hunting yields extra materials like bandages
+                            this.resourceManager.addResource('bandage', 1);
+                        }
                         this.map.removeResourceNode(this.currentTask.targetX, this.currentTask.targetY);
                         console.log(`${this.name} completed ${this.currentTask.type} and is now carrying ${this.carrying.type}.`);
                         this.currentTask = null;


### PR DESCRIPTION
## Summary
- reward bandages for completing a hunt_animal task
- test bandage reward when hunting animals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885023dc87c8323b91f90cb8ae2384d