### PR TITLE
Implement single-pile hauling mechanic

### DIFF
--- a/__tests__/Settler.test.js
+++ b/__tests__/Settler.test.js
@@ -398,4 +398,18 @@ describe('Settler', () => {
         expect(droppedPile.quantity).toBe(2);
         expect(settler.carrying).toBe(null);
     });
+
+    test('should drop current pile when picking up new one', () => {
+        settler.carrying = { type: 'wood', quantity: 1 };
+        settler.x = 1;
+        settler.y = 1;
+
+        settler.pickUpPile('stone', 1);
+
+        expect(settler.map.addResourcePile).toHaveBeenCalled();
+        const dropped = settler.map.addResourcePile.mock.calls[0][0];
+        expect(dropped.type).toBe('wood');
+        expect(dropped.quantity).toBe(1);
+        expect(settler.carrying).toEqual({ type: 'stone', quantity: 1 });
+    });
 });

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -68,6 +68,21 @@ export default class Settler {
         }
     }
 
+    pickUpPile(type, quantity) {
+        if (this.carrying) {
+            const dropX = Math.floor(this.x);
+            const dropY = Math.floor(this.y);
+            const existingPile = this.map.resourcePiles.find(p => p.x === dropX && p.y === dropY && p.type === this.carrying.type);
+            if (existingPile) {
+                existingPile.add(this.carrying.quantity);
+            } else {
+                const newPile = new ResourcePile(this.carrying.type, this.carrying.quantity, dropX, dropY, this.map.tileSize, this.spriteManager);
+                this.map.addResourcePile(newPile);
+            }
+        }
+        this.carrying = { type, quantity };
+    }
+
     setTargetEnemy(enemy) {
         this.targetEnemy = enemy;
         if (enemy) {
@@ -280,7 +295,7 @@ export default class Settler {
                     this.currentTask.quantity -= amountToMine; // Decrease task workload
 
                     if (this.currentTask.quantity <= 0) {
-                        this.carrying = { type: resourceType, quantity: 1 }; // Settler carries the resource
+                        this.pickUpPile(resourceType, 1); // Settler carries the resource
                         if (this.currentTask.type === "dig_dirt") {
                             this.map.tiles[this.currentTask.targetY][this.currentTask.targetX] = 1; // Change tile to dirt
                         } else {
@@ -297,7 +312,7 @@ export default class Settler {
                     this.currentTask.quantity -= amountToGather;
 
                     if (this.currentTask.quantity <= 0) {
-                        this.carrying = { type: resourceType, quantity: 1 }; // Settler carries the resource
+                        this.pickUpPile(resourceType, 1); // Settler carries the resource
                         if (this.currentTask.type === "hunt_animal") {
                             // Hunting yields extra materials like bandages dropped on the ground
                             const bandagePile = new ResourcePile('bandage', 1, this.currentTask.targetX, this.currentTask.targetY, this.map.tileSize, this.spriteManager);
@@ -319,7 +334,7 @@ export default class Settler {
 
                         if (this.currentTask.quantity <= 0) {
                             const lootType = this.currentTask.targetEnemy.lootType || 'meat';
-                            this.carrying = { type: lootType, quantity: 1 };
+                            this.pickUpPile(lootType, 1);
                             this.currentTask.targetEnemy.isButchered = true;
                             this.currentTask.targetEnemy.isMarkedForButcher = false;
                             console.log(`${this.name} butchered ${this.currentTask.targetEnemy.name}.`);
@@ -383,7 +398,7 @@ export default class Settler {
                                 if (pile.quantity <= 0) {
                                     this.map.resourcePiles = this.map.resourcePiles.filter(p => p !== pile);
                                 }
-                                this.carrying = { type: this.currentTask.resourceType, quantity: this.currentTask.quantity };
+                                this.pickUpPile(this.currentTask.resourceType, this.currentTask.quantity);
                                 this.currentTask.resource = this.carrying;
                                 this.currentTask.targetX = building.x;
                                 this.currentTask.targetY = building.y;
@@ -413,7 +428,7 @@ export default class Settler {
                             if (pile.quantity <= 0) {
                                 this.map.resourcePiles = this.map.resourcePiles.filter(p => p !== pile);
                             }
-                            this.carrying = { type: this.currentTask.resourceType, quantity: this.currentTask.quantity };
+                            this.pickUpPile(this.currentTask.resourceType, this.currentTask.quantity);
                             this.currentTask.resource = this.carrying;
                             const target = this.roomManager.findStorageRoomAndTile(this.currentTask.resourceType);
                             if (target) {


### PR DESCRIPTION
## Summary
- add a `pickUpPile` helper to Settler that drops the current pile before picking a new one
- use `pickUpPile` when acquiring resources
- test dropping the carried pile when a new pile is picked up

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68850d511e8083238cad3cee66dbf484