### PR TITLE
Implement check for storage piles

### DIFF
--- a/__tests__/RoomManager.test.js
+++ b/__tests__/RoomManager.test.js
@@ -37,4 +37,16 @@ describe('RoomManager storage rules', () => {
         expect(taskManager.tasks[0].targetX).toBe(2); // initial target is pile
         expect(taskManager.tasks[0].targetY).toBe(2);
     });
+
+    test('piles already in storage do not create haul tasks', () => {
+        const map = new Map(5, 5, 32, { getSprite: jest.fn() });
+        const taskManager = new TaskManager();
+        const roomManager = new RoomManager(map, { getSprite: jest.fn() }, 32, taskManager);
+
+        map.addResourcePile(new ResourcePile('wood', 5, 1, 1, 32, { getSprite: jest.fn() }));
+
+        roomManager.designateRoom(1, 1, 1, 1, 'storage');
+
+        expect(taskManager.tasks.length).toBe(0);
+    });
 });

--- a/src/js/roomManager.js
+++ b/src/js/roomManager.js
@@ -170,6 +170,10 @@ export default class RoomManager {
     assignHaulingTasksForDroppedPiles() {
         if (!this.taskManager) return;
         for (const pile of this.map.resourcePiles) {
+            const roomAtPile = this.getRoomAt(pile.x, pile.y);
+            if (roomAtPile && roomAtPile.type === 'storage') {
+                continue; // Already in storage
+            }
             const target = this.findStorageRoomAndTile(pile.type);
             if (!target) continue;
             const existing = this.taskManager.tasks.some(


### PR DESCRIPTION
## Summary
- avoid assigning haul tasks for piles that are already in a storage room
- add regression test for this behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688514cbc718832388fd7f297364291c