### PR TITLE
Implement ally defense behavior

### DIFF
--- a/__tests__/SettlerCombat.test.js
+++ b/__tests__/SettlerCombat.test.js
@@ -78,4 +78,18 @@ describe('Settler Health and Combat', () => {
         expect(settler.targetEnemy).toBe(enemy);
         expect(settler.state).toBe('combat');
     });
+
+    test('idle allies target attacker when settler is hit', () => {
+        const settlers = [];
+        const alice = new Settler('Alice', 0, 0, mockResourceManager, mockMap, mockRoomManager, undefined, settlers);
+        const bob = new Settler('Bob', 1, 1, mockResourceManager, mockMap, mockRoomManager, undefined, settlers);
+        settlers.push(alice, bob);
+
+        const enemy = new Enemy('Goblin', 1, 1, null, { getSprite: jest.fn() });
+
+        alice.takeDamage('torso', 5, false, enemy);
+
+        expect(bob.targetEnemy).toBe(enemy);
+        expect(bob.state).toBe('combat');
+    });
 });

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -100,8 +100,8 @@ export default class Game {
         this.map.addResourcePile(new ResourcePile('stone', 50, 3, 2, this.map.tileSize, this.spriteManager));
 
         // Create a new settler
-        this.settlers.push(new Settler("Alice", 5, 5, this.resourceManager, this.map, this.roomManager, this.spriteManager));
-        this.settlers.push(new Settler("Bob", 6, 5, this.resourceManager, this.map, this.roomManager, this.spriteManager));
+        this.settlers.push(new Settler("Alice", 5, 5, this.resourceManager, this.map, this.roomManager, this.spriteManager, this.settlers));
+        this.settlers.push(new Settler("Bob", 6, 5, this.resourceManager, this.map, this.roomManager, this.spriteManager, this.settlers));
 
         window.addEventListener('keydown', this.handleKeyDown);
         window.addEventListener('keyup', this.handleKeyUp);
@@ -331,10 +331,11 @@ export default class Game {
             const gameState = JSON.parse(savedState);
 
             // Restore settlers
-            this.settlers = gameState.settlers.map(sData => {
-                const settler = new Settler(sData.name, sData.x, sData.y, this.resourceManager, this.map, this.roomManager);
+            this.settlers = [];
+            gameState.settlers.forEach(sData => {
+                const settler = new Settler(sData.name, sData.x, sData.y, this.resourceManager, this.map, this.roomManager, this.spriteManager, this.settlers);
                 settler.deserialize(sData);
-                return settler;
+                this.settlers.push(settler);
             });
 
             // After all settlers and enemies are deserialized, re-link their targets

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -3,11 +3,12 @@ import Task from './task.js';
 import ResourcePile from './resourcePile.js';
 
 export default class Settler {
-    constructor(name, x, y, resourceManager, map, roomManager, spriteManager) {
+    constructor(name, x, y, resourceManager, map, roomManager, spriteManager, allSettlers = null) {
         this.resourceManager = resourceManager;
         this.map = map;
         this.roomManager = roomManager;
         this.spriteManager = spriteManager;
+        this.allSettlers = allSettlers;
         this.name = name;
         this.x = x;
         this.y = y;
@@ -562,6 +563,17 @@ export default class Settler {
                     this.currentTask = null;
                 }
                 this.state = "combat";
+                if (this.allSettlers) {
+                    this.allSettlers.forEach(ally => {
+                        if (ally !== this && !ally.isDead && ally.state === 'idle' && !ally.currentTask) {
+                            const distance = Math.sqrt(Math.pow(ally.x - this.x, 2) + Math.pow(ally.y - this.y, 2));
+                            if (distance <= 5) {
+                                ally.setTargetEnemy(attacker);
+                                ally.state = 'combat';
+                            }
+                        }
+                    });
+                }
             }
             if (this.health <= 0) {
                 this.isDead = true;


### PR DESCRIPTION
## Summary
- allow settlers to share their allies array
- support allies defending each other when attacked
- update game to pass settlers array
- restore settlers with shared array on load
- test that idle allies target attackers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68851b4bb34483238a2d58097ad6498e