### PR TITLE
Prevent duplicate hauling tasks

### DIFF
--- a/__tests__/RoomManager.test.js
+++ b/__tests__/RoomManager.test.js
@@ -49,4 +49,18 @@ describe('RoomManager storage rules', () => {
 
         expect(taskManager.tasks.length).toBe(0);
     });
+
+    test('does not create duplicate haul tasks when settler already hauling', () => {
+        const map = new Map(5, 5, 32, { getSprite: jest.fn() });
+        const taskManager = new TaskManager();
+        const roomManager = new RoomManager(map, { getSprite: jest.fn() }, 32, taskManager);
+        const settlers = [{ currentTask: { type: 'haul', sourceX: 2, sourceY: 2, resourceType: 'wood' } }];
+        roomManager.setSettlers(settlers);
+
+        map.addResourcePile(new ResourcePile('wood', 5, 2, 2, 32, { getSprite: jest.fn() }));
+
+        roomManager.assignHaulingTasksForDroppedPiles(settlers);
+
+        expect(taskManager.tasks.length).toBe(0);
+    });
 });

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -47,6 +47,7 @@ export default class Game {
         this.soundManager = new SoundManager();
         this.notificationManager = new NotificationManager(this.soundManager);
         this.settlers = [];
+        this.roomManager.setSettlers(this.settlers);
         this.enemies = [];
         this.keys = {};
         this.isPaused = false; // Track pause state
@@ -133,7 +134,7 @@ export default class Game {
         // Periodically assign hauling tasks for dropped resource piles
         this.haulingCheckTimer += (deltaTime / 1000) * this.gameSpeed;
         if (this.haulingCheckTimer >= this.haulingCheckInterval) {
-            this.roomManager.assignHaulingTasksForDroppedPiles();
+            this.roomManager.assignHaulingTasksForDroppedPiles(this.settlers);
             this.haulingCheckTimer = 0;
         }
         


### PR DESCRIPTION
## Summary
- track settlers in `RoomManager`
- ensure hauling tasks aren't added if a settler is already hauling the pile
- expose `setSettlers` helper and wire it in `Game`
- update game update loop to pass settlers
- add regression test for duplicate hauling tasks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68852364de1c83238282bdc4e3a8534a