### PR TITLE
Move wheat to pile-based system

### DIFF
--- a/__tests__/Settler.test.js
+++ b/__tests__/Settler.test.js
@@ -240,7 +240,10 @@ describe('Settler', () => {
 
         settler.updateNeeds(1000); // Simulate enough time for task to complete
         expect(mockFarmPlot.harvest).toHaveBeenCalled();
-        expect(mockResourceManager.addResource).toHaveBeenCalledWith('wheat', 1);
+        expect(settler.map.addResourcePile).toHaveBeenCalled();
+        const addedPile = settler.map.addResourcePile.mock.calls[0][0];
+        expect(addedPile.type).toBe('wheat');
+        expect(addedPile.quantity).toBe(1);
         expect(settler.currentTask).toBe(null);
     });
 

--- a/src/js/eventManager.js
+++ b/src/js/eventManager.js
@@ -1,4 +1,5 @@
 
+import ResourcePile from './resourcePile.js';
 export default class EventManager {
     constructor(game, EnemyClass) {
         this.EnemyClass = EnemyClass;
@@ -68,7 +69,8 @@ export default class EventManager {
                         farmPlots.forEach(plot => {
                             const harvestedCrop = plot.harvest();
                             if (harvestedCrop) {
-                                this.game.resourceManager.addResource(harvestedCrop, 2); // Double the harvest
+                                const pile = new ResourcePile(harvestedCrop, 2, plot.x, plot.y, this.game.map.tileSize, this.game.spriteManager);
+                                this.game.map.addResourcePile(pile);
                                 console.log(`Doubled harvest from a farm plot: ${harvestedCrop}!`);
                                 this.game.notificationManager.addNotification(`Doubled harvest from a farm plot: ${harvestedCrop}!`, 'success');
                             }

--- a/src/js/resourcePile.js
+++ b/src/js/resourcePile.js
@@ -24,6 +24,7 @@ export default class ResourcePile extends Resource {
         const mushroomsSprite = this.spriteManager.getSprite('mushrooms');
         const bandageSprite = this.spriteManager.getSprite('bandage');
         const dirtPileSprite = this.spriteManager.getSprite('dirt_pile');
+        const wheatSprite = this.spriteManager.getSprite('wheat_3');
         if (this.type === 'wood' && woodSprite) {
             ctx.drawImage(woodSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
         } else if (this.type === 'stone' && stonePileSprite) {
@@ -38,6 +39,8 @@ export default class ResourcePile extends Resource {
             ctx.drawImage(bandageSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
         } else if (this.type === 'dirt' && dirtPileSprite) {
             ctx.drawImage(dirtPileSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
+        } else if (this.type === 'wheat' && wheatSprite) {
+            ctx.drawImage(wheatSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
         }
         else {
             ctx.fillStyle = 'brown'; // Placeholder color for wood piles

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -354,8 +354,9 @@ export default class Settler {
                     const farmPlot = this.currentTask.building;
                     const harvestedCrop = farmPlot.harvest();
                     if (harvestedCrop) {
-                        this.resourceManager.addResource(harvestedCrop, 1); // Add 1 unit of harvested crop
-                        console.log(`${this.name} harvested ${harvestedCrop} from ${farmPlot.x},${farmPlot.y}.`);
+                        const pile = new ResourcePile(harvestedCrop, 1, farmPlot.x, farmPlot.y, this.map.tileSize, this.spriteManager);
+                        this.map.addResourcePile(pile);
+                        console.log(`${this.name} harvested ${harvestedCrop} from ${farmPlot.x},${farmPlot.y} and created a pile.`);
                     } else {
                         console.log(`${this.name} failed to harvest at ${farmPlot.x},${farmPlot.y}.`);
                     }


### PR DESCRIPTION
## Summary
- spawn a resource pile on harvest instead of adding wheat to the global inventory
- drop resource piles during the Good Harvest event
- render wheat piles with the mature wheat sprite
- update tests for new wheat pile behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885252f8ec883239bf63745bdfef38b