### PR TITLE
Fix hauling logic when settlers carry items

### DIFF
--- a/__tests__/GameGatheringBehavior.test.js
+++ b/__tests__/GameGatheringBehavior.test.js
@@ -1,0 +1,24 @@
+import Game from '../src/js/game.js';
+import Settler from '../src/js/settler.js';
+import Task from '../src/js/task.js';
+
+describe('Game gathering behavior', () => {
+    test('settler carrying resource ignores new gather tasks', () => {
+        const ctx = { canvas: { width: 800, height: 600 }, clearRect: jest.fn(), drawImage: jest.fn() };
+        const game = new Game(ctx);
+        const settler = new Settler('Bob', 0, 0, game.resourceManager, game.map, game.roomManager, game.spriteManager, game.settlers);
+        settler.updateNeeds = jest.fn();
+        settler.carrying = { type: 'wood', quantity: 1 };
+        settler.state = 'idle';
+        game.settlers.push(settler);
+        game.roomManager.setSettlers(game.settlers);
+
+        const gatherTask = new Task('chop_wood', 0, 0, 'wood', 1, 2);
+        game.taskManager.addTask(gatherTask);
+
+        game.update(16);
+
+        expect(settler.currentTask).toBe(null);
+        expect(game.taskManager.tasks.length).toBe(1);
+    });
+});

--- a/__tests__/GameHaulingBehavior.test.js
+++ b/__tests__/GameHaulingBehavior.test.js
@@ -1,0 +1,27 @@
+import Game from '../src/js/game.js';
+import Settler from '../src/js/settler.js';
+import Task from '../src/js/task.js';
+
+// This test uses the real modules to verify that settlers do not
+// pick up haul tasks when they are already carrying a resource.
+
+describe('Game hauling behavior', () => {
+    test('settler carrying resource ignores haul tasks', () => {
+        const ctx = { canvas: { width: 800, height: 600 }, clearRect: jest.fn(), drawImage: jest.fn() };
+        const game = new Game(ctx);
+        const settler = new Settler('Bob', 0, 0, game.resourceManager, game.map, game.roomManager, game.spriteManager, game.settlers);
+        settler.updateNeeds = jest.fn();
+        settler.carrying = { type: 'wood', quantity: 1 };
+        settler.state = 'idle';
+        game.settlers.push(settler);
+        game.roomManager.setSettlers(game.settlers);
+
+        const haulTask = new Task('haul', 0, 0, 'wood', 1, 2, null, null, null, null, null, null, null, 0, 0);
+        game.taskManager.addTask(haulTask);
+
+        game.update(16);
+
+        expect(settler.currentTask).toBe(null);
+        expect(game.taskManager.tasks.length).toBe(1);
+    });
+});

--- a/__tests__/TaskManager.test.js
+++ b/__tests__/TaskManager.test.js
@@ -42,4 +42,17 @@ describe('TaskManager', () => {
         expect(taskManager.tasks[1]).toBe(taskMedium);
         expect(taskManager.tasks[2]).toBe(taskLow);
     });
+
+    test('getTask can use a filter function', () => {
+        const haulTask = new Task('haul', 1, 1);
+        const buildTask = new Task('build', 2, 2);
+        taskManager.addTask(haulTask);
+        taskManager.addTask(buildTask);
+
+        const task = taskManager.getTask(t => t.type === 'build');
+
+        expect(task).toBe(buildTask);
+        expect(taskManager.tasks).toContain(haulTask);
+        expect(taskManager.tasks).not.toContain(buildTask);
+    });
 });

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -156,7 +156,7 @@ export default class Game {
                 }
             }
             if (settler.state === "idle" && !settler.currentTask) {
-                const task = this.taskManager.getTask();
+                const task = this.taskManager.getTask(t => !(settler.carrying && t.type === 'haul'));
                 if (task) {
                     settler.currentTask = task;
                     console.log(`${settler.name} picked up task: ${task.type}`);

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -22,6 +22,16 @@ import EventManager from './eventManager.js';
 import NotificationManager from './notificationManager.js';
 import SoundManager, { ACTION_BEEP_URL } from './soundManager.js';
 
+const GATHER_TASK_TYPES = new Set([
+    'chop_wood',
+    'gather_berries',
+    'mushroom',
+    'hunt_animal',
+    'mine_stone',
+    'mine_iron_ore',
+    'dig_dirt'
+]);
+
 export default class Game {
     constructor(ctx) {
         this.ctx = ctx;
@@ -156,7 +166,10 @@ export default class Game {
                 }
             }
             if (settler.state === "idle" && !settler.currentTask) {
-                const task = this.taskManager.getTask(t => !(settler.carrying && t.type === 'haul'));
+                const task = this.taskManager.getTask(t => !(
+                    settler.carrying &&
+                    (t.type === 'haul' || GATHER_TASK_TYPES.has(t.type))
+                ));
                 if (task) {
                     settler.currentTask = task;
                     console.log(`${settler.name} picked up task: ${task.type}`);

--- a/src/js/taskManager.js
+++ b/src/js/taskManager.js
@@ -20,7 +20,15 @@ export default class TaskManager {
         this.tasks.splice(low, 0, task);
     }
 
-    getTask() {
+    getTask(filterFn = null) {
+        if (filterFn) {
+            for (let i = 0; i < this.tasks.length; i++) {
+                if (filterFn(this.tasks[i])) {
+                    return this.tasks.splice(i, 1)[0];
+                }
+            }
+            return null;
+        }
         if (this.tasks.length > 0) {
             return this.tasks.shift(); // Get the first task in the queue
         }


### PR DESCRIPTION
## Summary
- add optional filter to `TaskManager.getTask`
- prevent hauling task assignment when settlers are already carrying items
- cover new behavior with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885760028308323b9b820cb0b2b24e4