### PR TITLE
Fix building resource consumption

### DIFF
--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -417,7 +417,6 @@ export default class Settler {
                             const newPile = new ResourcePile(this.carrying.type, this.carrying.quantity, building.x, building.y, this.map.tileSize, this.spriteManager);
                             this.map.addResourcePile(newPile);
                         }
-                        building.resourcesDelivered += this.carrying.quantity;
                         const deliveredType = this.currentTask.resourceType;
                         this.carrying = null;
                         this.currentTask = null;


### PR DESCRIPTION
## Summary
- update hauling logic so dropping materials at a building no longer increments `resourcesDelivered`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885be24e4248323915cf3424b003729