### PR TITLE
Add sleeping mechanics

### DIFF
--- a/__tests__/Settler.test.js
+++ b/__tests__/Settler.test.js
@@ -463,4 +463,27 @@ describe('Settler', () => {
         expect(mockMap.resourcePiles.length).toBe(0);
         expect(settler.currentTask).toBe(null);
     });
+
+    test('seeking_sleep finds a bed and assigns sleep task', () => {
+        const bed = { type: 'bed', x: 1, y: 1, occupant: null };
+        mockMap.buildings = [bed];
+        settler.sleep = 10;
+
+        settler.updateNeeds(1000);
+
+        expect(settler.currentTask.type).toBe('sleep');
+        expect(settler.currentTask.bed).toBe(bed);
+    });
+
+    test('settler wakes up when attacked above 20 sleep', () => {
+        settler.isSleeping = true;
+        settler.sleep = 25;
+        settler.sleepingInBed = false;
+        const enemy = {};
+
+        settler.takeDamage('head', 5, false, enemy);
+
+        expect(settler.isSleeping).toBe(false);
+        expect(settler.state).toBe('combat');
+    });
 });

--- a/src/js/furniture.js
+++ b/src/js/furniture.js
@@ -4,6 +4,9 @@ export default class Furniture extends Building {
     constructor(type, x, y, width, height, material, health) {
         super(type, x, y, width, height, material, health);
         this.isFurniture = true;
+        if (type === 'bed') {
+            this.occupant = null; // Settler currently using the bed
+        }
     }
 
     render(ctx, tileSize) {


### PR DESCRIPTION
## Summary
- implement sleeping system with bed support
- track sleep gain, bed occupancy, and sleeping state
- wake settlers when attacked if rested
- serialize sleep-related properties
- add tests for new sleeping behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885bd6f29408323a88767bfc00c6b0e