### PR TITLE
Add building inventory system

### DIFF
--- a/__tests__/Building.test.js
+++ b/__tests__/Building.test.js
@@ -1,5 +1,7 @@
 import Building from '../src/js/building.js';
 
+import Map from '../src/js/map.js';
+
 describe('Building', () => {
     test('takeDamage reduces health and does not go below zero', () => {
         const building = new Building('barricade', 0, 0, 1, 1, 'wood', 100);
@@ -7,5 +9,20 @@ describe('Building', () => {
         expect(building.health).toBe(70);
         building.takeDamage(100);
         expect(building.health).toBe(0);
+    });
+
+    test('spillInventory drops resources as piles', () => {
+        const map = new Map(10, 10, 32, { getSprite: jest.fn() });
+        const building = new Building('wall', 1, 1, 1, 1, 'wood', 0, 5);
+        building.addToInventory('wood', 5);
+        map.addBuilding(building);
+
+        building.spillInventory(map);
+
+        expect(map.resourcePiles.length).toBe(1);
+        const pile = map.resourcePiles[0];
+        expect(pile.type).toBe('wood');
+        expect(pile.quantity).toBe(5);
+        expect(building.getResourceQuantity('wood')).toBe(0);
     });
 });

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -1,3 +1,5 @@
+import ResourcePile from './resourcePile.js';
+
 export default class Building {
     constructor(type, x, y, width, height, material, buildProgress, resourcesRequired = 1) {
         this.type = type; // e.g., "wall", "floor", "house"
@@ -12,6 +14,46 @@ export default class Building {
 
         // New properties for resource delivery
         this.resourcesRequired = resourcesRequired;
+        this.resourcesDelivered = 0;
+
+        // Inventory to hold delivered materials
+        this.inventory = {};
+    }
+
+    addToInventory(type, quantity) {
+        if (!this.inventory[type]) {
+            this.inventory[type] = 0;
+        }
+        this.inventory[type] += quantity;
+        if (type === this.material) {
+            this.resourcesDelivered = this.inventory[type];
+        }
+    }
+
+    removeFromInventory(type, quantity) {
+        if (this.inventory[type] && this.inventory[type] >= quantity) {
+            this.inventory[type] -= quantity;
+            if (type === this.material) {
+                this.resourcesDelivered = this.inventory[type];
+            }
+            return true;
+        }
+        return false;
+    }
+
+    getResourceQuantity(type) {
+        return this.inventory[type] || 0;
+    }
+
+    spillInventory(map) {
+        for (const type in this.inventory) {
+            const quantity = this.inventory[type];
+            if (quantity > 0) {
+                const pile = new ResourcePile(type, quantity, this.x, this.y, map.tileSize, map.spriteManager);
+                map.addResourcePile(pile);
+            }
+        }
+        this.inventory = {};
         this.resourcesDelivered = 0;
     }
 
@@ -45,7 +87,8 @@ export default class Building {
             resourcesRequired: this.resourcesRequired,
             resourcesDelivered: this.resourcesDelivered,
             maxHealth: this.maxHealth,
-            health: this.health
+            health: this.health,
+            inventory: this.inventory
         };
     }
 
@@ -61,5 +104,6 @@ export default class Building {
         this.resourcesDelivered = data.resourcesDelivered ?? 0;
         this.maxHealth = data.maxHealth;
         this.health = data.health;
+        this.inventory = data.inventory || {};
     }
 }

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -542,6 +542,7 @@ export default class Game {
                 } else if (typeof clickedBuilding.takeDamage === 'function') {
                     clickedBuilding.takeDamage(25); // Example: 25 damage per click
                     if (clickedBuilding.health <= 0) {
+                        clickedBuilding.spillInventory(this.map);
                         this.map.removeBuilding(clickedBuilding);
                         console.log(`Building at ${tileX},${tileY} destroyed.`);
                     }

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -227,18 +227,14 @@ export default class Settler {
                     const amountToConsume = consumptionRate * (deltaTime / 1000);
 
                     if (building.resourcesDelivered < building.resourcesRequired) {
-                        const pile = this.map.resourcePiles.find(p => p.x === building.x && p.y === building.y && p.type === material);
-                        if (pile && pile.remove(amountToConsume)) {
-                            building.resourcesDelivered += amountToConsume;
-                            if (pile.quantity <= 0) {
-                                this.map.resourcePiles = this.map.resourcePiles.filter(p => p !== pile);
-                            }
-                        } else if (this.carrying && this.carrying.type === material) {
+                        if (this.carrying && this.carrying.type === material) {
                             const needed = building.resourcesRequired - building.resourcesDelivered;
                             const amountToDrop = Math.min(needed, this.carrying.quantity);
-                            building.resourcesDelivered += amountToDrop;
+                            building.addToInventory(material, amountToDrop);
                             this.carrying.quantity -= amountToDrop;
                             if (this.carrying.quantity <= 0) this.carrying = null;
+                        } else if (building.getResourceQuantity(material) >= amountToConsume) {
+                            building.resourcesDelivered = building.getResourceQuantity(material);
                         } else {
                             console.log(`${this.name} needs ${material} delivered to build site.`);
                             this.currentTask = null;
@@ -410,14 +406,7 @@ export default class Settler {
                             }
                         }
                     } else if (this.carrying && this.x === building.x && this.y === building.y) {
-                        const existingPile = this.map.resourcePiles.find(p => p.x === building.x && p.y === building.y && p.type === this.carrying.type);
-                        if (existingPile) {
-                            existingPile.add(this.carrying.quantity);
-                        } else {
-                            const newPile = new ResourcePile(this.carrying.type, this.carrying.quantity, building.x, building.y, this.map.tileSize, this.spriteManager);
-                            this.map.addResourcePile(newPile);
-                        }
-                        building.resourcesDelivered += this.carrying.quantity;
+                        building.addToInventory(this.carrying.type, this.carrying.quantity);
                         const deliveredType = this.currentTask.resourceType;
                         this.carrying = null;
                         this.currentTask = null;


### PR DESCRIPTION
## Summary
- add inventory handling to `Building`
- drop building inventory as resource piles when the building is destroyed
- deliver materials directly into building inventories
- adjust build task logic for the new inventory
- test new inventory behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885bfae936483239641bf0cac5f34a2