### PR TITLE
Increase unit walking speed

### DIFF
--- a/src/js/enemy.js
+++ b/src/js/enemy.js
@@ -38,7 +38,7 @@ export default class Enemy {
                 this.targetSettler = null;
             } else {
                 // Move towards the target settler
-                const speed = 0.03; // tiles per second
+                const speed = 0.3; // tiles per second
                 if (this.x < this.targetSettler.x) {
                     this.x += speed * (deltaTime / 1000);
                 } else if (this.x > this.targetSettler.x) {

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -241,7 +241,7 @@ export default class Settler {
         // Execute current task
         if (this.currentTask) {
             // Move towards the target
-            const speed = 0.05; // tiles per second
+            const speed = 0.5; // tiles per second
             if (this.x < this.currentTask.targetX) {
                 this.x += speed * (deltaTime / 1000);
             } else if (this.x > this.currentTask.targetX) {
@@ -570,7 +570,7 @@ export default class Settler {
             }
         } else if (this.state === "combat" && this.targetEnemy) {
             // Move towards the enemy
-            const speed = 0.05; // tiles per second
+            const speed = 0.5; // tiles per second
             const distance = Math.sqrt(Math.pow(this.x - this.targetEnemy.x, 2) + Math.pow(this.y - this.targetEnemy.y, 2));
             const attackRange = 1.5; // Settler needs to be within this range to attack
 


### PR DESCRIPTION
## Summary
- boost settlers' movement speed
- make enemies move faster

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885c1e568008323b7311e22a4c3f5bb