### PR TITLE
Use RESOURCE_TYPES constants across game

### DIFF
--- a/src/js/animalPen.js
+++ b/src/js/animalPen.js
@@ -1,8 +1,9 @@
 import Building from './building.js';
+import { RESOURCE_TYPES } from './constants.js';
 
 export default class AnimalPen extends Building {
     constructor(x, y) {
-        super('animal_pen', x, y, 2, 2, 'wood', 100); // Animal pens are 2x2, built with wood, 100 health
+        super('animal_pen', x, y, 2, 2, RESOURCE_TYPES.WOOD, 100); // Animal pens are 2x2, built with wood, 100 health
         this.animals = []; // Array to hold animals
         this.maxAnimals = 5; // Max animals the pen can hold
     }

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -1,4 +1,5 @@
 import ResourcePile from './resourcePile.js';
+import { RESOURCE_TYPES } from './constants.js';
 
 export default class Building {
     constructor(type, x, y, width, height, material, buildProgress, resourcesRequired = 1) {
@@ -68,7 +69,7 @@ export default class Building {
         } else {
             // Render based on health
             const healthOpacity = this.health / this.maxHealth;
-            ctx.fillStyle = this.material === "wood" ? `rgba(139, 69, 19, ${healthOpacity})` : `rgba(128, 128, 128, ${healthOpacity})`;
+            ctx.fillStyle = this.material === RESOURCE_TYPES.WOOD ? `rgba(139, 69, 19, ${healthOpacity})` : `rgba(128, 128, 128, ${healthOpacity})`;
         }
         ctx.fillRect(this.x * tileSize, this.y * tileSize, this.width * tileSize, this.height * tileSize);
         ctx.strokeStyle = "black";

--- a/src/js/craftingStation.js
+++ b/src/js/craftingStation.js
@@ -1,14 +1,15 @@
 import Building from './building.js';
 import Recipe from './recipe.js';
+import { RESOURCE_TYPES } from './constants.js';
 
 export default class CraftingStation extends Building {
     constructor(x, y) {
-        super("crafting_station", x, y, 1, 1, "wood", 0);
+        super("crafting_station", x, y, 1, 1, RESOURCE_TYPES.WOOD, 0);
         this.recipes = []; // List of recipes this station can craft
 
         // Add example recipes
-        this.addRecipe(new Recipe("plank_from_wood", [{ resourceType: "wood", quantity: 1 }], [{ resourceType: "plank", quantity: 1, quality: 1 }], 5));
-        this.addRecipe(new Recipe("block_from_stone", [{ resourceType: "stone", quantity: 1 }], [{ resourceType: "block", quantity: 1, quality: 1 }], 7));
+        this.addRecipe(new Recipe("plank_from_wood", [{ resourceType: RESOURCE_TYPES.WOOD, quantity: 1 }], [{ resourceType: RESOURCE_TYPES.PLANK, quantity: 1, quality: 1 }], 5));
+        this.addRecipe(new Recipe("block_from_stone", [{ resourceType: RESOURCE_TYPES.STONE, quantity: 1 }], [{ resourceType: RESOURCE_TYPES.BLOCK, quantity: 1, quality: 1 }], 7));
     }
 
     addRecipe(recipe) {

--- a/src/js/enemy.js
+++ b/src/js/enemy.js
@@ -1,11 +1,11 @@
 
 import Settler from './settler.js';
-import { ENEMY_RUN_SPEED } from './constants.js';
+import { ENEMY_RUN_SPEED, RESOURCE_TYPES } from './constants.js';
 
 let enemyIdCounter = 0;
 
 export default class Enemy {
-    constructor(name, x, y, targetSettler, spriteManager, lootType = 'meat') {
+    constructor(name, x, y, targetSettler, spriteManager, lootType = RESOURCE_TYPES.MEAT) {
         this.id = enemyIdCounter++;
         this.name = name;
         this.x = x;
@@ -157,7 +157,7 @@ export default class Enemy {
         this.isDead = data.isDead || false;
         this.isButchered = data.isButchered || false;
         this.isMarkedForButcher = data.isMarkedForButcher || false;
-        this.lootType = data.lootType || 'meat';
+        this.lootType = data.lootType || RESOURCE_TYPES.MEAT;
         this.decay = data.decay || 0;
     }
 }

--- a/src/js/eventManager.js
+++ b/src/js/eventManager.js
@@ -1,5 +1,6 @@
 
 import ResourcePile from './resourcePile.js';
+import { RESOURCE_TYPES } from './constants.js';
 export default class EventManager {
     constructor(game, EnemyClass) {
         this.EnemyClass = EnemyClass;
@@ -23,7 +24,7 @@ export default class EventManager {
                     // Spawn a new enemy
                     if (this.game.settlers.length > 0) {
                         const targetSettler = this.game.settlers[Math.floor(Math.random() * this.game.settlers.length)];
-                        this.game.enemies.push(new this.EnemyClass("Wild Boar", 49, 29, targetSettler, this.game.spriteManager, 'meat'));
+                        this.game.enemies.push(new this.EnemyClass("Wild Boar", 49, 29, targetSettler, this.game.spriteManager, RESOURCE_TYPES.MEAT));
                         console.log("A wild boar has appeared!");
                     this.game.notificationManager.addNotification("A wild boar has appeared!", 'warning');
                     }
@@ -36,7 +37,7 @@ export default class EventManager {
                 action: () => {
                     console.log("Event: Resource Discovery!");
                     this.game.notificationManager.addNotification("You discovered a new resource node!", 'info');
-                    const resourceTypes = ["wood", "stone", "iron_ore"];
+                    const resourceTypes = [RESOURCE_TYPES.WOOD, RESOURCE_TYPES.STONE, RESOURCE_TYPES.IRON_ORE];
                     const randomResource = resourceTypes[Math.floor(Math.random() * resourceTypes.length)];
                     const quantity = Math.floor(Math.random() * 50) + 20; // 20-70 units
                     this.game.resourceManager.addResource(randomResource, quantity);

--- a/src/js/farmPlot.js
+++ b/src/js/farmPlot.js
@@ -1,5 +1,6 @@
 import Building from './building.js';
 import SpriteManager from './spriteManager.js';
+import { RESOURCE_TYPES } from './constants.js';
 
 export default class FarmPlot extends Building {
     constructor(x, y, spriteManager) {
@@ -53,7 +54,7 @@ export default class FarmPlot extends Building {
 
         // Render crop based on growth stage
         if (this.crop) {
-            if (this.crop === 'wheat') {
+            if (this.crop === RESOURCE_TYPES.WHEAT) {
                 let spriteName;
                 const currentGrowthStage = Math.floor(this.growthStage);
                 if (currentGrowthStage === 1) {

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -21,7 +21,7 @@ import Enemy from './enemy.js';
 import EventManager from './eventManager.js';
 import NotificationManager from './notificationManager.js';
 import SoundManager from './soundManager.js';
-import { ACTION_BEEP_URL, GATHER_TASK_TYPES, TASK_TYPES } from './constants.js';
+import { ACTION_BEEP_URL, GATHER_TASK_TYPES, TASK_TYPES, RESOURCE_TYPES } from './constants.js';
 
 
 export default class Game {
@@ -77,22 +77,22 @@ export default class Game {
             await this.spriteManager.loadImage('grass', 'src/assets/grass.png');
             await this.spriteManager.loadImage('berry_bush', 'src/assets/berry_bush.png');
             await this.spriteManager.loadImage('goblin', 'src/assets/goblin.png');
-            await this.spriteManager.loadImage('stone', 'src/assets/stone.png');
-            await this.spriteManager.loadImage('iron_ore', 'src/assets/iron_ore.png');
+            await this.spriteManager.loadImage(RESOURCE_TYPES.STONE, 'src/assets/stone.png');
+            await this.spriteManager.loadImage(RESOURCE_TYPES.IRON_ORE, 'src/assets/iron_ore.png');
             await this.spriteManager.loadImage('deer', 'src/assets/deer.png');
-            await this.spriteManager.loadImage('dirt', 'src/assets/dirt.png');
+            await this.spriteManager.loadImage(RESOURCE_TYPES.DIRT, 'src/assets/dirt.png');
             await this.spriteManager.loadImage('wild_boar', 'src/assets/wild_boar.png');
             await this.spriteManager.loadImage('mushroom', 'src/assets/mushroom.png');
             await this.spriteManager.loadImage('mushrooms', 'src/assets/mushrooms.png');
-            await this.spriteManager.loadImage('wood', 'src/assets/wood.png');
+            await this.spriteManager.loadImage(RESOURCE_TYPES.WOOD, 'src/assets/wood.png');
             await this.spriteManager.loadImage('stone_pile', 'src/assets/stone_pile.png');
-            await this.spriteManager.loadImage('berries', 'src/assets/berries.png');
-            await this.spriteManager.loadImage('meat', 'src/assets/meat.png');
+            await this.spriteManager.loadImage(RESOURCE_TYPES.BERRIES, 'src/assets/berries.png');
+            await this.spriteManager.loadImage(RESOURCE_TYPES.MEAT, 'src/assets/meat.png');
             await this.soundManager.loadSound('action', ACTION_BEEP_URL);
             
             await this.spriteManager.loadImage('dirt_pile', 'src/assets/dirt_pile.png');
             await this.spriteManager.loadImage('farm_plot', 'src/assets/farmPlot.png');
-            await this.spriteManager.loadImage('bandage', 'src/assets/bandage.png');
+            await this.spriteManager.loadImage(RESOURCE_TYPES.BANDAGE, 'src/assets/bandage.png');
             await this.spriteManager.loadImage('wheat_1', 'src/assets/wheat_1.png');
             await this.spriteManager.loadImage('wheat_2', 'src/assets/wheat_2.png');
             await this.spriteManager.loadImage('wheat_3', 'src/assets/wheat_3.png');
@@ -147,7 +147,7 @@ export default class Game {
         // Update settler needs
         this.settlers.forEach(settler => {
             settler.updateNeeds(deltaTime * this.gameSpeed);
-            if (settler.needsTreatment() && this.map.resourcePiles.some(p => p.type === 'bandage' && p.quantity > 0)) {
+            if (settler.needsTreatment() && this.map.resourcePiles.some(p => p.type === RESOURCE_TYPES.BANDAGE && p.quantity > 0)) {
                 const availableSettler = this.settlers.find(s => s.state === 'idle' && s !== settler);
                 const existingTreatmentTask = this.taskManager.hasTaskForTargetSettler(settler) ||
                                              this.settlers.some(s => s.currentTask && s.currentTask.type === TASK_TYPES.TREATMENT && s.currentTask.targetSettler === settler);
@@ -311,7 +311,7 @@ export default class Game {
     spawnTravelingMerchant() {
         console.log("A traveling merchant has arrived!");
         // Example trade: buy 10 wood for 5 gold
-        this.tradeManager.initiateTrade('traders', [{ type: 'buy', resource: 'wood', quantity: 10, price: 5 }]);
+        this.tradeManager.initiateTrade('traders', [{ type: 'buy', resource: RESOURCE_TYPES.WOOD, quantity: 10, price: 5 }]);
         // Example trade: sell 5 food for 10 gold
         this.tradeManager.initiateTrade('traders', [{ type: 'sell', resource: 'food', quantity: 5, price: 10 }]);
     }
@@ -478,15 +478,15 @@ export default class Game {
             } else if (this.selectedBuilding === 'animal_pen') {
                 newBuilding = new AnimalPen(tileX, tileY);
             } else if (this.selectedBuilding === 'bed') {
-                newBuilding = new Furniture('bed', tileX, tileY, 1, 2, 'wood', 50);
+                newBuilding = new Furniture('bed', tileX, tileY, 1, 2, RESOURCE_TYPES.WOOD, 50);
             } else if (this.selectedBuilding === 'table') {
-                newBuilding = new Furniture('table', tileX, tileY, 2, 1, 'wood', 75);
+                newBuilding = new Furniture('table', tileX, tileY, 2, 1, RESOURCE_TYPES.WOOD, 75);
             } else if (this.selectedBuilding === 'barricade') {
-                newBuilding = new Building('barricade', tileX, tileY, 1, 1, "wood", 0); // Barricade is a simple building
+                newBuilding = new Building('barricade', tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 0); // Barricade is a simple building
             } else if (this.selectedBuilding === 'wall') {
-                newBuilding = new Building('wall', tileX, tileY, 1, 1, 'wood', 0, 1); // Walls require 1 wood
+                newBuilding = new Building('wall', tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 0, 1); // Walls require 1 wood
             } else {
-                newBuilding = new Building(this.selectedBuilding, tileX, tileY, 1, 1, "wood", 0); // Start with 0 health
+                newBuilding = new Building(this.selectedBuilding, tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 0); // Start with 0 health
             }
             this.map.addBuilding(newBuilding);
             // Hauling should happen before building starts if resources are needed
@@ -530,7 +530,7 @@ export default class Game {
                 } else if (clickedBuilding.type === 'farm_plot') {
                     const farmPlot = clickedBuilding;
                     if (farmPlot.growthStage === 0) {
-                        this.taskManager.addTask(new Task(TASK_TYPES.SOW_CROP, tileX, tileY, null, 0, 3, farmPlot, null, 'wheat')); // Hardcode wheat for now
+                        this.taskManager.addTask(new Task(TASK_TYPES.SOW_CROP, tileX, tileY, null, 0, 3, farmPlot, null, RESOURCE_TYPES.WHEAT)); // Hardcode wheat for now
                         console.log(`Sow crop task added for wheat at ${tileX},${tileY}`);
                     } else if (farmPlot.growthStage === 3) {
                         this.taskManager.addTask(new Task(TASK_TYPES.HARVEST_CROP, tileX, tileY, null, 0, 3, farmPlot));
@@ -555,26 +555,26 @@ export default class Game {
             } else {
                 const clickedEnemy = this.enemies.find(e => Math.floor(e.x) === tileX && Math.floor(e.y) === tileY);
                 if (clickedEnemy && clickedEnemy.isDead && clickedEnemy.decay <= 50 && !clickedEnemy.isMarkedForButcher && !clickedEnemy.isButchered) {
-                    this.taskManager.addTask(new Task(TASK_TYPES.BUTCHER, tileX, tileY, "meat", 1, 2, null, null, null, null, null, null, clickedEnemy));
+                    this.taskManager.addTask(new Task(TASK_TYPES.BUTCHER, tileX, tileY, RESOURCE_TYPES.MEAT, 1, 2, null, null, null, null, null, null, clickedEnemy));
                     clickedEnemy.isMarkedForButcher = true;
                     console.log(`Butcher task added at ${tileX},${tileY}`);
                 } else if (clickedTile === 2) { // If a tree is clicked
-                    this.taskManager.addTask(new Task(TASK_TYPES.CHOP_WOOD, tileX, tileY, "wood", 2.5, 2));
+                    this.taskManager.addTask(new Task(TASK_TYPES.CHOP_WOOD, tileX, tileY, RESOURCE_TYPES.WOOD, 2.5, 2));
                     console.log(`Chop wood task added at ${tileX},${tileY}`);
                 } else if (clickedTile === 3) { // If a stone is clicked
-                    this.taskManager.addTask(new Task(TASK_TYPES.MINE_STONE, tileX, tileY, "stone", 2.5, 2));
+                    this.taskManager.addTask(new Task(TASK_TYPES.MINE_STONE, tileX, tileY, RESOURCE_TYPES.STONE, 2.5, 2));
                     console.log(`Mine stone task added at ${tileX},${tileY}`);
                 } else if (clickedTile === 4) { // If berries are clicked
-                    this.taskManager.addTask(new Task(TASK_TYPES.GATHER_BERRIES, tileX, tileY, "berries", 1, 2));
+                    this.taskManager.addTask(new Task(TASK_TYPES.GATHER_BERRIES, tileX, tileY, RESOURCE_TYPES.BERRIES, 1, 2));
                     console.log(`Gather berries task added at ${tileX},${tileY}`);
                 } else if (clickedTile === 5) { // If iron_ore is clicked
-                    this.taskManager.addTask(new Task(TASK_TYPES.MINE_IRON_ORE, tileX, tileY, "iron_ore", 10, 2));
+                    this.taskManager.addTask(new Task(TASK_TYPES.MINE_IRON_ORE, tileX, tileY, RESOURCE_TYPES.IRON_ORE, 10, 2));
                     console.log(`Mine iron ore task added at ${tileX},${tileY}`);
                 } else if (clickedTile === 6) { // If wild food is clicked
-                    this.taskManager.addTask(new Task(TASK_TYPES.MUSHROOM, tileX, tileY, "mushrooms", 1, 2));
+                    this.taskManager.addTask(new Task(TASK_TYPES.MUSHROOM, tileX, tileY, RESOURCE_TYPES.MUSHROOMS, 1, 2));
                     console.log(`Forage food task added at ${tileX},${tileY}`);
                 } else if (clickedTile === 7) { // If animal is clicked
-                    this.taskManager.addTask(new Task(TASK_TYPES.HUNT_ANIMAL, tileX, tileY, "meat", 2.5, 2));
+                    this.taskManager.addTask(new Task(TASK_TYPES.HUNT_ANIMAL, tileX, tileY, RESOURCE_TYPES.MEAT, 2.5, 2));
                     console.log(`Hunt animal task added at ${tileX},${tileY}`);
                 }
             }

--- a/src/js/resourcePile.js
+++ b/src/js/resourcePile.js
@@ -1,5 +1,6 @@
 
 import Resource from './resource.js';
+import { RESOURCE_TYPES } from './constants.js';
 
 export default class ResourcePile extends Resource {
     static MAX_QUANTITY = 999;
@@ -17,32 +18,32 @@ export default class ResourcePile extends Resource {
     }
 
     render(ctx) {
-        const woodSprite = this.spriteManager.getSprite('wood');
+        const woodSprite = this.spriteManager.getSprite(RESOURCE_TYPES.WOOD);
         const stonePileSprite = this.spriteManager.getSprite('stone_pile');
-        const berriesSprite = this.spriteManager.getSprite('berries');
-        const meatSprite = this.spriteManager.getSprite('meat');
-        const mushroomsSprite = this.spriteManager.getSprite('mushrooms');
-        const bandageSprite = this.spriteManager.getSprite('bandage');
+        const berriesSprite = this.spriteManager.getSprite(RESOURCE_TYPES.BERRIES);
+        const meatSprite = this.spriteManager.getSprite(RESOURCE_TYPES.MEAT);
+        const mushroomsSprite = this.spriteManager.getSprite(RESOURCE_TYPES.MUSHROOMS);
+        const bandageSprite = this.spriteManager.getSprite(RESOURCE_TYPES.BANDAGE);
         const dirtPileSprite = this.spriteManager.getSprite('dirt_pile');
         const wheatPileSprite = this.spriteManager.getSprite('wheat_pile');
         const ironOrePileSprite = this.spriteManager.getSprite('iron_ore_pile');
-        if (this.type === 'wood' && woodSprite) {
+        if (this.type === RESOURCE_TYPES.WOOD && woodSprite) {
             ctx.drawImage(woodSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
-        } else if (this.type === 'stone' && stonePileSprite) {
+        } else if (this.type === RESOURCE_TYPES.STONE && stonePileSprite) {
             ctx.drawImage(stonePileSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
-        } else if (this.type === 'berries' && berriesSprite) {
+        } else if (this.type === RESOURCE_TYPES.BERRIES && berriesSprite) {
             ctx.drawImage(berriesSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
-        } else if (this.type === 'meat' && meatSprite) {
+        } else if (this.type === RESOURCE_TYPES.MEAT && meatSprite) {
             ctx.drawImage(meatSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
-        } else if (this.type === 'mushrooms' && mushroomsSprite) {
+        } else if (this.type === RESOURCE_TYPES.MUSHROOMS && mushroomsSprite) {
             ctx.drawImage(mushroomsSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
-        } else if (this.type === 'bandage' && bandageSprite) {
+        } else if (this.type === RESOURCE_TYPES.BANDAGE && bandageSprite) {
             ctx.drawImage(bandageSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
-        } else if (this.type === 'dirt' && dirtPileSprite) {
+        } else if (this.type === RESOURCE_TYPES.DIRT && dirtPileSprite) {
             ctx.drawImage(dirtPileSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
-        } else if (this.type === 'wheat' && wheatPileSprite) {
+        } else if (this.type === RESOURCE_TYPES.WHEAT && wheatPileSprite) {
             ctx.drawImage(wheatPileSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
-        } else if (this.type === 'iron_ore' && ironOrePileSprite) {
+        } else if (this.type === RESOURCE_TYPES.IRON_ORE && ironOrePileSprite) {
             ctx.drawImage(ironOrePileSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
         }
         else {

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -1,7 +1,7 @@
 
 import Task from './task.js';
 import ResourcePile from './resourcePile.js';
-import { SLEEP_GAIN_RATE, SETTLER_RUN_SPEED, TASK_TYPES } from './constants.js';
+import { SLEEP_GAIN_RATE, SETTLER_RUN_SPEED, TASK_TYPES, RESOURCE_TYPES } from './constants.js';
 
 export default class Settler {
     constructor(name, x, y, resourceManager, map, roomManager, spriteManager, allSettlers = null) {
@@ -154,7 +154,7 @@ export default class Settler {
         // Basic AI: Change state based on needs
         if (this.targetEnemy && this.targetEnemy.health > 0) {
             this.state = "combat";
-        } else if (this.needsTreatment() && this.map.resourcePiles.some(p => p.type === 'bandage' && p.quantity > 0)) {
+        } else if (this.needsTreatment() && this.map.resourcePiles.some(p => p.type === RESOURCE_TYPES.BANDAGE && p.quantity > 0)) {
             this.state = "seeking_treatment";
         } else if (this.hunger < 20) {
             this.state = "seeking_food";
@@ -179,7 +179,7 @@ export default class Settler {
             const storageRooms = this.roomManager.rooms.filter(room => room.type === "storage");
             let assigned = false;
             for (const room of storageRooms) {
-                const foodTypes = ["berries", "mushrooms", "meat"];
+                const foodTypes = [RESOURCE_TYPES.BERRIES, RESOURCE_TYPES.MUSHROOMS, RESOURCE_TYPES.MEAT];
                 for (const food of foodTypes) {
                     if (room.storage[food] && room.storage[food] > 0) {
                         const targetTile = room.tiles[0];
@@ -367,7 +367,7 @@ export default class Settler {
                         this.pickUpPile(resourceType, 1); // Settler carries the resource
                         if (this.currentTask.type === TASK_TYPES.HUNT_ANIMAL) {
                             // Hunting yields extra materials like bandages dropped on the ground
-                            const bandagePile = new ResourcePile('bandage', 1, this.currentTask.targetX, this.currentTask.targetY, this.map.tileSize, this.spriteManager);
+                            const bandagePile = new ResourcePile(RESOURCE_TYPES.BANDAGE, 1, this.currentTask.targetX, this.currentTask.targetY, this.map.tileSize, this.spriteManager);
                             this.map.addResourcePile(bandagePile);
                         }
                         this.map.removeResourceNode(this.currentTask.targetX, this.currentTask.targetY);
@@ -385,7 +385,7 @@ export default class Settler {
                         this.currentTask.quantity -= amountToButcher;
 
                         if (this.currentTask.quantity <= 0) {
-                            const lootType = this.currentTask.targetEnemy.lootType || 'meat';
+                            const lootType = this.currentTask.targetEnemy.lootType || RESOURCE_TYPES.MEAT;
                             this.pickUpPile(lootType, 1);
                             this.currentTask.targetEnemy.isButchered = true;
                             this.currentTask.targetEnemy.isMarkedForButcher = false;
@@ -522,7 +522,7 @@ export default class Settler {
 
                     if (!this.currentTask.stage) {
                         this.currentTask.stage = 'pickup';
-                        const pile = this.map.resourcePiles.find(p => p.type === 'bandage' && p.quantity > 0);
+                        const pile = this.map.resourcePiles.find(p => p.type === RESOURCE_TYPES.BANDAGE && p.quantity > 0);
                         if (pile) {
                             this.currentTask.sourceX = pile.x;
                             this.currentTask.sourceY = pile.y;
@@ -537,14 +537,14 @@ export default class Settler {
 
                     if (this.currentTask.stage === 'pickup') {
                         if (this.x === this.currentTask.targetX && this.y === this.currentTask.targetY) {
-                            const pile = this.map.resourcePiles.find(p => p.x === this.currentTask.sourceX && p.y === this.currentTask.sourceY && p.type === 'bandage');
+                            const pile = this.map.resourcePiles.find(p => p.x === this.currentTask.sourceX && p.y === this.currentTask.sourceY && p.type === RESOURCE_TYPES.BANDAGE);
                             if (pile && pile.remove(1)) {
                                 if (pile.quantity <= 0) {
                                     this.map.resourcePiles = this.map.resourcePiles.filter(p => p !== pile);
                                 }
-                                this.pickUpPile('bandage', 1);
+                                this.pickUpPile(RESOURCE_TYPES.BANDAGE, 1);
                                 if (this.x === targetSettler.x && this.y === targetSettler.y) {
-                                    if (this.carrying && this.carrying.type === 'bandage') {
+                                    if (this.carrying && this.carrying.type === RESOURCE_TYPES.BANDAGE) {
                                         this.carrying.quantity -= 1;
                                         if (this.carrying.quantity <= 0) this.carrying = null;
                                         targetSettler.stopBleeding();
@@ -563,7 +563,7 @@ export default class Settler {
                         }
                     } else if (this.currentTask.stage === 'treat') {
                         if (this.x === targetSettler.x && this.y === targetSettler.y) {
-                            if (this.carrying && this.carrying.type === 'bandage') {
+                            if (this.carrying && this.carrying.type === RESOURCE_TYPES.BANDAGE) {
                                 this.carrying.quantity -= 1;
                                 if (this.carrying.quantity <= 0) this.carrying = null;
                                 targetSettler.stopBleeding();

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -1,5 +1,5 @@
 
-import { TASK_TYPES } from './constants.js';
+import { TASK_TYPES, RESOURCE_TYPES } from './constants.js';
 
 export default class UI {
     constructor(ctx) {
@@ -133,7 +133,7 @@ export default class UI {
         addBandageButton.textContent = 'Add Bandage';
         addBandageButton.onclick = () => {
             if (this.gameInstance) {
-                this.gameInstance.resourceManager.addResource('bandage', 1);
+                this.gameInstance.resourceManager.addResource(RESOURCE_TYPES.BANDAGE, 1);
             }
         };
         this.buildMenu.appendChild(addBandageButton);


### PR DESCRIPTION
## Summary
- import RESOURCE_TYPES and replace string literals for resource types
- adjust crafting recipes and building materials to use constants
- update tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885d05a10788323a766404797478506