### PR TITLE
Add task priority system with UI

### DIFF
--- a/__tests__/Settler.test.js
+++ b/__tests__/Settler.test.js
@@ -62,6 +62,9 @@ describe('Settler', () => {
             combat: 1,
             medical: 1
         });
+        Object.values(TASK_TYPES).forEach(type => {
+            expect(settler.taskPriorities[type]).toBe(5);
+        });
     });
 
     test('updateNeeds should decrease hunger and sleep over time', () => {

--- a/__tests__/TaskManager.test.js
+++ b/__tests__/TaskManager.test.js
@@ -56,4 +56,18 @@ describe('TaskManager', () => {
         expect(taskManager.tasks).toContain(haulTask);
         expect(taskManager.tasks).not.toContain(buildTask);
     });
+
+    test('getTaskForSettler respects settler priorities', () => {
+        const settler = { taskPriorities: { [TASK_TYPES.BUILD]: 0, [TASK_TYPES.HAUL]: 5 } };
+        const haulTask = new Task(TASK_TYPES.HAUL, 1, 1);
+        const buildTask = new Task(TASK_TYPES.BUILD, 2, 2);
+        taskManager.addTask(buildTask);
+        taskManager.addTask(haulTask);
+
+        const task = taskManager.getTaskForSettler(settler);
+
+        expect(task).toBe(haulTask);
+        expect(taskManager.tasks).toContain(buildTask);
+        expect(taskManager.tasks).not.toContain(haulTask);
+    });
 });

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -11,3 +11,7 @@ canvas {
     border: 2px solid #555; /* Simple border for the canvas */
     background-color: #000; /* Black background for the game area */
 }
+
+#priority-overlay h3 {
+    margin-top: 0;
+}

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -158,7 +158,7 @@ export default class Game {
                 }
             }
             if (settler.state === "idle" && !settler.currentTask) {
-                const task = this.taskManager.getTask(t => !(
+                const task = this.taskManager.getTaskForSettler(settler, t => !(
                     settler.carrying &&
                     (t.type === TASK_TYPES.HAUL || GATHER_TASK_TYPES.has(t.type))
                 ));

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -36,6 +36,10 @@ export default class Settler {
             combat: 1,
             medical: 1
         };
+        this.taskPriorities = {};
+        Object.values(TASK_TYPES).forEach(type => {
+            this.taskPriorities[type] = 5;
+        });
         this.equippedWeapon = null; // Stores a Weapon object
         this.equippedArmor = {}; // Stores Armor objects by body part (e.g., { head: ArmorObject, torso: ArmorObject })
         this.targetEnemy = null; // The enemy the settler is currently targeting
@@ -765,7 +769,8 @@ export default class Settler {
             targetEnemy: this.targetEnemy ? { id: this.targetEnemy.id } : null, // Only save ID, actual object will be re-linked
             isDead: this.isDead,
             isSleeping: this.isSleeping,
-            sleepingInBed: this.sleepingInBed
+            sleepingInBed: this.sleepingInBed,
+            taskPriorities: this.taskPriorities
         };
     }
 
@@ -816,5 +821,8 @@ export default class Settler {
         this.isDead = data.isDead || false;
         this.isSleeping = data.isSleeping || false;
         this.sleepingInBed = data.sleepingInBed || false;
+        if (data.taskPriorities) {
+            this.taskPriorities = data.taskPriorities;
+        }
     }
 }

--- a/src/js/taskManager.js
+++ b/src/js/taskManager.js
@@ -36,6 +36,19 @@ export default class TaskManager {
         return null;
     }
 
+    getTaskForSettler(settler, filterFn = null) {
+        for (let i = 0; i < this.tasks.length; i++) {
+            const task = this.tasks[i];
+            if (settler.taskPriorities && settler.taskPriorities[task.type] > 0) {
+                if (!filterFn || filterFn(task)) {
+                    this.tasks.splice(i, 1);
+                    return task;
+                }
+            }
+        }
+        return null;
+    }
+
     // You might want more sophisticated methods later, like:
     // assignTask(settler) { ... }
     // removeTask(task) { ... }

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -173,6 +173,11 @@ export default class UI {
         this.helpButton.onclick = () => this.toggleHelp();
         this.uiContainer.appendChild(this.helpButton);
 
+        this.priorityButton = document.createElement('button');
+        this.priorityButton.textContent = 'Task Priorities';
+        this.priorityButton.onclick = () => this.togglePriorityManager();
+        this.uiContainer.appendChild(this.priorityButton);
+
         this.helpOverlay = document.createElement('div');
         this.helpOverlay.id = 'help-overlay';
         this.helpOverlay.style.position = 'absolute';
@@ -203,6 +208,22 @@ export default class UI {
         helpContent.appendChild(closeHelpButton);
         this.helpOverlay.appendChild(helpContent);
         document.body.appendChild(this.helpOverlay);
+
+        this.priorityOverlay = document.createElement('div');
+        this.priorityOverlay.id = 'priority-overlay';
+        this.priorityOverlay.style.position = 'absolute';
+        this.priorityOverlay.style.top = '0';
+        this.priorityOverlay.style.left = '0';
+        this.priorityOverlay.style.width = '100%';
+        this.priorityOverlay.style.height = '100%';
+        this.priorityOverlay.style.backgroundColor = 'rgba(0, 0, 0, 0.8)';
+        this.priorityOverlay.style.color = 'white';
+        this.priorityOverlay.style.padding = '20px';
+        this.priorityOverlay.style.boxSizing = 'border-box';
+        this.priorityOverlay.style.display = 'none';
+        this.priorityOverlay.style.overflow = 'auto';
+        this.priorityOverlay.style.zIndex = '1001';
+        document.body.appendChild(this.priorityOverlay);
 
         this.tooltip = document.createElement('div');
         this.tooltip.id = 'tooltip';
@@ -330,6 +351,54 @@ export default class UI {
             this.showHelp();
         } else {
             this.hideHelp();
+        }
+    }
+
+    showPriorityManager() {
+        if (!this.gameInstance) return;
+        this.priorityOverlay.innerHTML = '';
+        this.gameInstance.settlers.forEach(settler => {
+            const settlerDiv = document.createElement('div');
+            settlerDiv.innerHTML = `<h3>${settler.name}</h3>`;
+            Object.keys(settler.taskPriorities).forEach(taskType => {
+                const container = document.createElement('div');
+                const label = document.createElement('label');
+                label.textContent = taskType;
+                label.style.marginRight = '10px';
+                const slider = document.createElement('input');
+                slider.type = 'range';
+                slider.min = '0';
+                slider.max = '10';
+                slider.value = settler.taskPriorities[taskType];
+                const valueSpan = document.createElement('span');
+                valueSpan.textContent = slider.value;
+                slider.addEventListener('input', () => {
+                    valueSpan.textContent = slider.value;
+                    settler.taskPriorities[taskType] = parseInt(slider.value);
+                });
+                container.appendChild(label);
+                container.appendChild(slider);
+                container.appendChild(valueSpan);
+                settlerDiv.appendChild(container);
+            });
+            this.priorityOverlay.appendChild(settlerDiv);
+        });
+        const closeBtn = document.createElement('button');
+        closeBtn.textContent = 'Close';
+        closeBtn.onclick = () => this.hidePriorityManager();
+        this.priorityOverlay.appendChild(closeBtn);
+        this.priorityOverlay.style.display = 'block';
+    }
+
+    hidePriorityManager() {
+        this.priorityOverlay.style.display = 'none';
+    }
+
+    togglePriorityManager() {
+        if (this.priorityOverlay.style.display === 'none') {
+            this.showPriorityManager();
+        } else {
+            this.hidePriorityManager();
         }
     }
 }


### PR DESCRIPTION
## Summary
- give each settler a `taskPriorities` map and include it in save/load
- provide `TaskManager.getTaskForSettler` to respect these priorities
- assign tasks in `Game` via the new method
- add UI overlay to adjust task priorities per settler
- small CSS tweak for overlay
- test coverage for new functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885dab5f7308323a25b5e1104e4c31f