### PR TITLE
Allow settlers to treat themselves

### DIFF
--- a/__tests__/Settler.test.js
+++ b/__tests__/Settler.test.js
@@ -484,6 +484,22 @@ describe('Settler', () => {
         expect(settler.currentTask).toBe(null);
     });
 
+    test('settler can treat themselves', () => {
+        const patient = new Settler('SelfHealer', 0, 0, mockResourceManager, mockMap, mockRoomManager);
+        patient.bodyParts.head.bleeding = true;
+        mockMap.resourcePiles.push(new ResourcePile('bandage', 1, 0, 0, 1, { getSprite: jest.fn() }));
+        const task = new Task('treatment', 0, 0, null, 0, 5, null, null, null, null, null, patient);
+        patient.currentTask = task;
+        patient.x = 0;
+        patient.y = 0;
+
+        patient.updateNeeds(1000);
+
+        expect(patient.needsTreatment()).toBe(false);
+        expect(mockMap.resourcePiles.length).toBe(0);
+        expect(patient.currentTask).toBe(null);
+    });
+
     test('seeking_sleep finds a bed and assigns sleep task', () => {
         const bed = { type: 'bed', x: 1, y: 1, occupant: null };
         mockMap.buildings = [bed];

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -148,7 +148,10 @@ export default class Game {
         this.settlers.forEach(settler => {
             settler.updateNeeds(deltaTime * this.gameSpeed);
             if (settler.needsTreatment() && this.map.resourcePiles.some(p => p.type === RESOURCE_TYPES.BANDAGE && p.quantity > 0)) {
-                const availableSettler = this.settlers.find(s => s.state === 'idle' && s !== settler);
+                const availableSettler = this.settlers.find(s =>
+                    !s.currentTask &&
+                    (s.state === 'idle' || (s === settler && s.state === 'seeking_treatment'))
+                );
                 const existingTreatmentTask = this.taskManager.hasTaskForTargetSettler(settler) ||
                                              this.settlers.some(s => s.currentTask && s.currentTask.type === TASK_TYPES.TREATMENT && s.currentTask.targetSettler === settler);
 

--- a/src/js/taskManager.js
+++ b/src/js/taskManager.js
@@ -55,7 +55,9 @@ export default class TaskManager {
             let bestSettler = null;
             let bestPriority = -1;
             settlers.forEach(settler => {
-                if (settler.state !== 'idle' || settler.currentTask) return;
+                if (settler.currentTask) return;
+                const isSelfTreatment = task.type === TASK_TYPES.TREATMENT && task.targetSettler === settler;
+                if (settler.state !== 'idle' && !(isSelfTreatment && settler.state === 'seeking_treatment')) return;
                 const priority = settler.taskPriorities ? settler.taskPriorities[task.type] : 0;
                 if (priority > 0 && (!filterFn || filterFn(task, settler))) {
                     if (priority > bestPriority) {


### PR DESCRIPTION
## Summary
- allow settlers in a seeking_treatment state to pick up treatment tasks
- permit game logic to assign self-treatment tasks when a settler is bleeding
- test that settlers can treat themselves

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885e31cce5483239b6d5407281008cb