### PR TITLE
Implement health regeneration based on hunger

### DIFF
--- a/__tests__/Settler.test.js
+++ b/__tests__/Settler.test.js
@@ -1,6 +1,6 @@
 import Settler from '../src/js/settler.js';
 import Task from '../src/js/task.js';
-import { TASK_TYPES } from '../src/js/constants.js';
+import { TASK_TYPES, HEALTH_REGEN_RATE } from '../src/js/constants.js';
 import ResourcePile from '../src/js/resourcePile.js';
 
 jest.mock('../src/js/resourceManager.js');
@@ -505,5 +505,19 @@ describe('Settler', () => {
 
         expect(settler.isSleeping).toBe(false);
         expect(settler.state).toBe('combat');
+    });
+
+    test('health regenerates based on hunger level', () => {
+        settler.bodyParts.head.health = 50;
+        settler.hunger = 100;
+        settler.updateNeeds(1000);
+        const expectedHigh = 50 + ((settler.hunger) / 100) * HEALTH_REGEN_RATE;
+        expect(settler.bodyParts.head.health).toBeCloseTo(expectedHigh, 5);
+
+        settler.bodyParts.head.health = 50;
+        settler.hunger = 50;
+        settler.updateNeeds(1000);
+        const expectedLow = 50 + ((settler.hunger) / 100) * HEALTH_REGEN_RATE;
+        expect(settler.bodyParts.head.health).toBeCloseTo(expectedLow, 5);
     });
 });

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -3,6 +3,7 @@
 // General constants
 export const ACTION_BEEP_URL = "data:audio/wav;base64,UklGRrQBAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YZABAACAq9Dt/P3v066DWDIUBAIOKU14o8rp+/7y2baLYDgZBgELI0Zwm8Tk+P72372TaD8eCAEIHj9ok73f9v745MSbcEYjCwEGGThgi7bZ8v776cqjeE0pDgIEFDJYg67T7/387dCrf1QvEgMCECxRfKfN6/v98dayh1w1FgQBDSZJdJ/H5vn+9Ny5j2Q7GwcBCSBCbJfA4ff/9+HAl2xCIAkBBxs7ZI+53PT++ebHn3RJJg0BBBY1XIey1vH9++vNp3xRLBACAxIvVICr0O38/e/TroNYMhQEAg4pTXijyun7/vLZtotgOBkGAQsjRnCbxOT4/vbfvZNoPx4IAQgeP2iTvd/2/vjkxJtwRiMLAQYZOGCLttny/vvpyqN4TSkOAgQUMliDrtPv/fzt0KuAVC8SAwIQLFF8p83r+/3x1rKHXDUWBAENJkl0n8fm+f703LmPZDsbBwEJIEJsl8Dh9//34cCXbEIgCQEHGztkj7nc9P755sefdEkmDQEEFjVch7LW8f37682nfFEsEAIDEi9U";
 export const SLEEP_GAIN_RATE = 0.01; // base sleep recovery per second
+export const HEALTH_REGEN_RATE = 0.005; // base health regen per second at full hunger
 
 // Resource types used throughout the game
 export const RESOURCE_TYPES = {

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -1,7 +1,7 @@
 
 import Task from './task.js';
 import ResourcePile from './resourcePile.js';
-import { SLEEP_GAIN_RATE, SETTLER_RUN_SPEED, TASK_TYPES, RESOURCE_TYPES } from './constants.js';
+import { SLEEP_GAIN_RATE, SETTLER_RUN_SPEED, TASK_TYPES, RESOURCE_TYPES, HEALTH_REGEN_RATE } from './constants.js';
 
 export default class Settler {
     constructor(name, x, y, resourceManager, map, roomManager, spriteManager, allSettlers = null) {
@@ -151,17 +151,17 @@ export default class Settler {
 
         // Update overall health based on body parts
         let totalHealth = 0;
-        let damagedParts = 0;
         for (const part in this.bodyParts) {
-            totalHealth += this.bodyParts[part].health;
-            if (this.bodyParts[part].health < 100) {
-                damagedParts++;
-            }
             // Simulate bleeding
             if (this.bodyParts[part].bleeding) {
                 this.bodyParts[part].health -= 0.01 * (deltaTime / 1000); // Bleeding causes health loss
                 if (this.bodyParts[part].health < 0) this.bodyParts[part].health = 0;
+            } else if (this.bodyParts[part].health < 100) {
+                // Regenerate health when not bleeding
+                this.bodyParts[part].health += (this.hunger / 100) * HEALTH_REGEN_RATE * (deltaTime / 1000);
+                if (this.bodyParts[part].health > 100) this.bodyParts[part].health = 100;
             }
+            totalHealth += this.bodyParts[part].health;
         }
         this.health = totalHealth / Object.keys(this.bodyParts).length; // Average health of all parts
 


### PR DESCRIPTION
## Summary
- add `HEALTH_REGEN_RATE` constant
- regenerate body part health in `Settler.updateNeeds`
- test hunger-based health regeneration

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6885e358ab3c832381e1350f695bb382