### PR TITLE
Implement resource categories

### DIFF
--- a/__tests__/Resource.test.js
+++ b/__tests__/Resource.test.js
@@ -1,4 +1,5 @@
 import Resource from '../src/js/resource.js';
+import { RESOURCE_CATEGORIES } from '../src/js/constants.js';
 
 describe('Resource', () => {
     test('should create a resource with correct properties and default quality', () => {
@@ -6,6 +7,7 @@ describe('Resource', () => {
         expect(wood.type).toBe('wood');
         expect(wood.quantity).toBe(100);
         expect(wood.quality).toBe(1);
+        expect(wood.categories).toEqual(RESOURCE_CATEGORIES.wood);
     });
 
     test('should create a resource with specified quality', () => {
@@ -13,6 +15,7 @@ describe('Resource', () => {
         expect(stone.type).toBe('stone');
         expect(stone.quantity).toBe(50);
         expect(stone.quality).toBe(0.5);
+        expect(stone.categories).toEqual(RESOURCE_CATEGORIES.stone);
     });
 
     test('should add quantity correctly', () => {
@@ -32,5 +35,11 @@ describe('Resource', () => {
         const result = water.remove(40);
         expect(water.quantity).toBe(30);
         expect(result).toBe(false);
+    });
+
+    test('should allow overriding categories', () => {
+        const custom = new Resource('custom', 5, 1, ['material', 'food']);
+        expect(custom.categories).toContain('material');
+        expect(custom.categories).toContain('food');
     });
 });

--- a/__tests__/ResourceManager.test.js
+++ b/__tests__/ResourceManager.test.js
@@ -51,4 +51,12 @@ describe('ResourceManager', () => {
         expect(allResources.wood.quantity).toBe(100);
         expect(allResources.stone.quantity).toBe(50);
     });
+
+    test('should filter resources by category', () => {
+        resourceManager.addResource('berries', 10);
+        resourceManager.addResource('wood', 5);
+        const foods = resourceManager.getResourcesByCategory('food');
+        expect(foods.some(r => r.type === 'berries')).toBe(true);
+        expect(foods.some(r => r.type === 'wood')).toBe(false);
+    });
 });

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -20,6 +20,22 @@ export const RESOURCE_TYPES = {
   BLOCK: 'block'
 };
 
+// Categories assigned to each resource. Resources can belong to multiple
+// categories (e.g., wheat is considered food).
+export const RESOURCE_CATEGORIES = {
+  [RESOURCE_TYPES.WOOD]: ['material'],
+  [RESOURCE_TYPES.STONE]: ['material'],
+  [RESOURCE_TYPES.IRON_ORE]: ['material'],
+  [RESOURCE_TYPES.DIRT]: ['material'],
+  [RESOURCE_TYPES.WHEAT]: ['food'],
+  [RESOURCE_TYPES.BERRIES]: ['food'],
+  [RESOURCE_TYPES.MUSHROOMS]: ['food'],
+  [RESOURCE_TYPES.MEAT]: ['food'],
+  [RESOURCE_TYPES.BANDAGE]: ['medical'],
+  [RESOURCE_TYPES.PLANK]: ['material'],
+  [RESOURCE_TYPES.BLOCK]: ['material']
+};
+
 // Individual task type constants
 export const TASK_TYPES = {
   CHOP_WOOD: 'chop_wood',

--- a/src/js/resource.js
+++ b/src/js/resource.js
@@ -1,9 +1,13 @@
 
+import { RESOURCE_CATEGORIES } from './constants.js';
+
 export default class Resource {
-    constructor(type, quantity, quality = 1) {
+    constructor(type, quantity, quality = 1, categories = null) {
         this.type = type; // e.g., "wood", "stone", "food"
         this.quantity = quantity;
         this.quality = quality; // 1-100 scale, affects efficiency/value
+        // Use provided categories or fall back to defaults for the resource type
+        this.categories = categories ?? (RESOURCE_CATEGORIES[type] || []);
     }
 
     add(amount) {
@@ -22,7 +26,8 @@ export default class Resource {
         return {
             type: this.type,
             quantity: this.quantity,
-            quality: this.quality
+            quality: this.quality,
+            categories: this.categories
         };
     }
 
@@ -30,5 +35,6 @@ export default class Resource {
         this.type = data.type;
         this.quantity = data.quantity;
         this.quality = data.quality;
+        this.categories = data.categories ?? (RESOURCE_CATEGORIES[this.type] || []);
     }
 }

--- a/src/js/resourceManager.js
+++ b/src/js/resourceManager.js
@@ -29,6 +29,10 @@ export default class ResourceManager {
         return this.resources;
     }
 
+    getResourcesByCategory(category) {
+        return Object.values(this.resources).filter(r => r.categories.includes(category));
+    }
+
     serialize() {
         const serializedResources = {};
         for (const type in this.resources) {
@@ -41,7 +45,12 @@ export default class ResourceManager {
         this.resources = {};
         for (const type in data) {
             const resourceData = data[type];
-            const resource = new Resource(resourceData.type, resourceData.quantity, resourceData.quality);
+            const resource = new Resource(
+                resourceData.type,
+                resourceData.quantity,
+                resourceData.quality,
+                resourceData.categories
+            );
             this.resources[type] = resource;
         }
     }

--- a/src/js/resourcePile.js
+++ b/src/js/resourcePile.js
@@ -56,9 +56,7 @@ export default class ResourcePile extends Resource {
 
     serialize() {
         return {
-            type: this.type,
-            quantity: this.quantity,
-            quality: this.quality,
+            ...super.serialize(),
             x: this.x,
             y: this.y,
             tileSize: this.tileSize
@@ -66,9 +64,8 @@ export default class ResourcePile extends Resource {
     }
 
     deserialize(data) {
-        this.type = data.type;
-        this.quantity = Math.min(data.quantity, ResourcePile.MAX_QUANTITY);
-        this.quality = data.quality;
+        super.deserialize(data);
+        this.quantity = Math.min(this.quantity, ResourcePile.MAX_QUANTITY);
         this.x = data.x;
         this.y = data.y;
         this.tileSize = data.tileSize;


### PR DESCRIPTION
## Summary
- categorize resources with `RESOURCE_CATEGORIES`
- store categories in `Resource` and `ResourcePile`
- expose filtering method in `ResourceManager`
- test category defaults and filtering

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6885e76216e08323a2243114a65cae7d