### PR TITLE
Fix slider click propagation

### DIFF
--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -223,6 +223,13 @@ export default class UI {
         this.priorityOverlay.style.display = 'none';
         this.priorityOverlay.style.overflow = 'auto';
         this.priorityOverlay.style.zIndex = '1001';
+        // Prevent clicks inside the overlay from reaching the game canvas
+        this.priorityOverlay.addEventListener('mousedown', (event) => {
+            event.stopPropagation();
+        });
+        this.priorityOverlay.addEventListener('click', (event) => {
+            event.stopPropagation();
+        });
         document.body.appendChild(this.priorityOverlay);
 
         this.tooltip = document.createElement('div');


### PR DESCRIPTION
## Summary
- prevent click events in the priority overlay from reaching the game canvas

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885e9a12e708323acb9bc7a2c2e23c1