### PR TITLE
Add farm plot action menu

### DIFF
--- a/__tests__/Game.test.js
+++ b/__tests__/Game.test.js
@@ -76,8 +76,11 @@ describe('Game', () => {
         game.map.addBuilding = jest.fn(); // Mock addBuilding
         game.ui.setGameInstance = jest.fn();
         game.ui.update = jest.fn();
+        game.ui.showFarmPlotMenu = jest.fn();
         game.resourceManager.addResource = jest.fn();
         game.resourceManager.getAllResources.mockReturnValue({});
+
+        game.map.getBuildingAt = jest.fn();
         
         game.settlers[0].render = jest.fn();
         game.settlers[0].hunger = 100;
@@ -178,6 +181,16 @@ describe('Game', () => {
         game.buildMode = false;
         game.handleClick({ clientX: 100, clientY: 100, target: { closest: () => null } });
         expect(game.map.addBuilding).not.toHaveBeenCalled();
+    });
+
+    test('handleClick on farm plot shows menu', () => {
+        const tileX = Math.floor(((100 - mockCtx.canvas.width / 2) / game.camera.zoom + game.camera.x) / game.map.tileSize);
+        const tileY = Math.floor(((100 - mockCtx.canvas.height / 2) / game.camera.zoom + game.camera.y) / game.map.tileSize);
+        const farmPlot = { type: 'farm_plot', x: tileX, y: tileY, growthStage: 0 };
+        game.map.getBuildingAt.mockReturnValue(farmPlot);
+        game.handleClick({ clientX: 100, clientY: 100, target: { closest: () => null } });
+        expect(game.ui.showFarmPlotMenu).toHaveBeenCalledWith(farmPlot, 100, 100);
+        expect(game.taskManager.addTask).not.toHaveBeenCalled();
     });
 
     test('handleClick should add wood and remove tree when tree is clicked', () => {

--- a/__tests__/UI.test.js
+++ b/__tests__/UI.test.js
@@ -36,4 +36,17 @@ describe('UI tooltips', () => {
         const ui = new UI({});
         expect(ui.priorityButton.parentElement).toBe(ui.buildMenu);
     });
+
+    test('farm plot menu shows with correct button states', () => {
+        const ui = new UI({});
+        const mockGame = { addSowCropTask: jest.fn(), addHarvestCropTask: jest.fn() };
+        ui.setGameInstance(mockGame);
+        const farmPlot = { crop: null, growthStage: 0, x: 1, y: 2 };
+        ui.showFarmPlotMenu(farmPlot, 10, 20);
+        expect(ui.farmPlotMenu.style.display).toBe('block');
+        expect(ui.plantWheatButton.disabled).toBe(false);
+        expect(ui.harvestButton.disabled).toBe(true);
+        ui.hideFarmPlotMenu();
+        expect(ui.farmPlotMenu.style.display).toBe('none');
+    });
 });

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -93,6 +93,15 @@ canvas {
     display: none;
 }
 
+#farm-plot-menu {
+    position: absolute;
+    background-color: rgba(0, 0, 0, 0.7);
+    padding: 10px;
+    border-radius: 5px;
+    display: none;
+    z-index: 1000;
+}
+
 .priority-label {
     margin-right: 10px;
 }

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -327,6 +327,28 @@ export default class Game {
         this.tradeManager.initiateTrade('traders', [{ type: 'sell', resource: 'food', quantity: 5, price: 10 }]);
     }
 
+    addSowCropTask(farmPlot) {
+        this.taskManager.addTask(
+            new Task(
+                TASK_TYPES.SOW_CROP,
+                farmPlot.x,
+                farmPlot.y,
+                null,
+                0,
+                3,
+                farmPlot,
+                null,
+                RESOURCE_TYPES.WHEAT
+            )
+        );
+    }
+
+    addHarvestCropTask(farmPlot) {
+        this.taskManager.addTask(
+            new Task(TASK_TYPES.HARVEST_CROP, farmPlot.x, farmPlot.y, null, 0, 3, farmPlot)
+        );
+    }
+
     saveGame() {
         const gameState = {
             settlers: this.settlers.map(settler => settler.serialize()),
@@ -549,15 +571,7 @@ export default class Game {
                         }
                     } else if (clickedBuilding.type === 'farm_plot') {
                         const farmPlot = clickedBuilding;
-                        if (farmPlot.growthStage === 0) {
-                            this.taskManager.addTask(new Task(TASK_TYPES.SOW_CROP, tileX, tileY, null, 0, 3, farmPlot, null, RESOURCE_TYPES.WHEAT)); // Hardcode wheat for now
-                            console.log(`Sow crop task added for wheat at ${tileX},${tileY}`);
-                        } else if (farmPlot.growthStage === 3) {
-                            this.taskManager.addTask(new Task(TASK_TYPES.HARVEST_CROP, tileX, tileY, null, 0, 3, farmPlot));
-                            console.log(`Harvest crop task added at ${tileX},${tileY}`);
-                        } else {
-                            console.log(`Farm plot at ${tileX},${tileY} is not ready for action.`);
-                        }
+                        this.ui.showFarmPlotMenu(farmPlot, event.clientX, event.clientY);
                     } else if (clickedBuilding.type === 'animal_pen') {
                         const animalPen = clickedBuilding;
                         this.taskManager.addTask(new Task(TASK_TYPES.TEND_ANIMALS, tileX, tileY, null, 0, 3, animalPen));

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -189,6 +189,32 @@ export default class UI {
         });
         document.body.appendChild(this.priorityOverlay);
 
+        this.farmPlotMenu = document.createElement('div');
+        this.farmPlotMenu.id = 'farm-plot-menu';
+        this.farmPlotMenu.style.display = 'none';
+        this.plantWheatButton = document.createElement('button');
+        this.plantWheatButton.textContent = 'Plant wheat';
+        this.plantWheatButton.onclick = () => {
+            if (this.gameInstance && this.selectedFarmPlot) {
+                this.gameInstance.addSowCropTask(this.selectedFarmPlot);
+            }
+            this.hideFarmPlotMenu();
+        };
+        this.harvestButton = document.createElement('button');
+        this.harvestButton.textContent = 'Harvest';
+        this.harvestButton.onclick = () => {
+            if (this.gameInstance && this.selectedFarmPlot) {
+                this.gameInstance.addHarvestCropTask(this.selectedFarmPlot);
+            }
+            this.hideFarmPlotMenu();
+        };
+        this.farmPlotMenu.appendChild(this.plantWheatButton);
+        this.farmPlotMenu.appendChild(this.harvestButton);
+        this.farmPlotMenu.addEventListener('mousedown', event => event.stopPropagation());
+        this.farmPlotMenu.addEventListener('click', event => event.stopPropagation());
+        document.addEventListener('click', () => this.hideFarmPlotMenu());
+        document.body.appendChild(this.farmPlotMenu);
+
         this.tooltip = document.createElement('div');
         this.tooltip.id = 'tooltip';
         document.body.appendChild(this.tooltip);
@@ -357,5 +383,19 @@ export default class UI {
         } else {
             this.hidePriorityManager();
         }
+    }
+
+    showFarmPlotMenu(farmPlot, screenX, screenY) {
+        this.selectedFarmPlot = farmPlot;
+        this.farmPlotMenu.style.left = `${screenX}px`;
+        this.farmPlotMenu.style.top = `${screenY}px`;
+        this.plantWheatButton.disabled = farmPlot.crop !== null;
+        this.harvestButton.disabled = farmPlot.growthStage !== 3;
+        this.farmPlotMenu.style.display = 'block';
+    }
+
+    hideFarmPlotMenu() {
+        this.farmPlotMenu.style.display = 'none';
+        this.selectedFarmPlot = null;
     }
 }


### PR DESCRIPTION
## Summary
- implement UI menu for farm plots with Plant and Harvest actions
- style farm plot menu
- expose helpers in Game to create sow and harvest tasks
- open farm plot menu when a plot is clicked
- test new UI and game behaviors

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68860afb77108323bf750f7fc4513f57