### PR TITLE
Add farm plot auto-sow/harvest

### DIFF
--- a/__tests__/FarmPlot.test.js
+++ b/__tests__/FarmPlot.test.js
@@ -7,6 +7,12 @@ describe('FarmPlot', () => {
         farm = new FarmPlot(0, 0, new SpriteManager());
     });
 
+    test('default settings', () => {
+        expect(farm.autoSow).toBe(false);
+        expect(farm.autoHarvest).toBe(false);
+        expect(farm.desiredCrop).toBe('wheat');
+    });
+
     test('plant sets crop and stage', () => {
         expect(farm.plant('wheat')).toBe(true);
         expect(farm.crop).toBe('wheat');

--- a/__tests__/Game.test.js
+++ b/__tests__/Game.test.js
@@ -261,6 +261,20 @@ describe('Game', () => {
         expect(game.tradeManager.initiateTrade).toHaveBeenCalledWith('traders', [{ type: 'sell', resource: 'food', quantity: 5, price: 10 }]);
     });
 
+    test('auto sow and harvest create tasks', () => {
+        const farmPlot = { type: 'farm_plot', x: 1, y: 2, crop: null, growthStage: 0, autoSow: true, autoHarvest: true, desiredCrop: 'wheat' };
+        game.map.getAllBuildings.mockReturnValue([farmPlot]);
+        game.taskManager.tasks = [];
+        game.update(16);
+        expect(game.taskManager.addTask).toHaveBeenCalledWith(expect.objectContaining({ type: TASK_TYPES.SOW_CROP }));
+
+        game.taskManager.addTask.mockClear();
+        farmPlot.crop = 'wheat';
+        farmPlot.growthStage = 3;
+        game.update(16);
+        expect(game.taskManager.addTask).toHaveBeenCalledWith(expect.objectContaining({ type: TASK_TYPES.HARVEST_CROP }));
+    });
+
     test('handleClick marks dead enemy for butchering', () => {
         game.map.tileSize = 32;
         const tileX = Math.floor(((100 - mockCtx.canvas.width / 2) / game.camera.zoom + game.camera.x) / game.map.tileSize);

--- a/__tests__/UI.test.js
+++ b/__tests__/UI.test.js
@@ -37,16 +37,17 @@ describe('UI tooltips', () => {
         expect(ui.priorityButton.parentElement).toBe(ui.buildMenu);
     });
 
-    test('farm plot menu shows with correct button states', () => {
+    test('farm plot menu shows with correct controls', () => {
         const ui = new UI({});
         const mockGame = { addSowCropTask: jest.fn(), addHarvestCropTask: jest.fn() };
         ui.setGameInstance(mockGame);
-        const farmPlot = { crop: null, growthStage: 0, x: 1, y: 2 };
+        const farmPlot = { crop: null, growthStage: 0, desiredCrop: 'wheat', autoSow: false, autoHarvest: false, x: 1, y: 2 };
         ui.showFarmPlotMenu(farmPlot, 10, 20);
         expect(ui.farmPlotMenu.style.display).toBe('block');
-        expect(ui.plantWheatButton.disabled).toBe(false);
-        expect(ui.plantCottonButton.disabled).toBe(false);
+        expect(ui.sowButton.disabled).toBe(false);
         expect(ui.harvestButton.disabled).toBe(true);
+        expect(ui.wheatRadio.checked).toBe(true);
+        expect(ui.autoSowCheckbox.checked).toBe(false);
         ui.hideFarmPlotMenu();
         expect(ui.farmPlotMenu.style.display).toBe('none');
     });

--- a/src/js/farmPlot.js
+++ b/src/js/farmPlot.js
@@ -11,6 +11,9 @@ export default class FarmPlot extends Building {
         this.growthRate = 0.01; // How fast it grows per game tick
         this.spriteManager = spriteManager;
         this.farmPlotSprite = spriteManager.getSprite('farm_plot');
+        this.autoSow = false;
+        this.autoHarvest = false;
+        this.desiredCrop = RESOURCE_TYPES.WHEAT;
     }
 
     plant(cropType) {

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -196,6 +196,24 @@ export default class Game {
                 building.update(deltaTime * this.gameSpeed);
             }
 
+            if (building.type === 'farm_plot') {
+                const farmPlot = building;
+                if (farmPlot.autoSow && farmPlot.crop === null) {
+                    const hasTask = this.taskManager.tasks.some(t => t.type === TASK_TYPES.SOW_CROP && t.building === farmPlot);
+                    const inProgress = this.settlers.some(s => s.currentTask && s.currentTask.type === TASK_TYPES.SOW_CROP && s.currentTask.building === farmPlot);
+                    if (!hasTask && !inProgress) {
+                        this.addSowCropTask(farmPlot, farmPlot.desiredCrop);
+                    }
+                }
+                if (farmPlot.autoHarvest && farmPlot.growthStage === 3) {
+                    const hasTask = this.taskManager.tasks.some(t => t.type === TASK_TYPES.HARVEST_CROP && t.building === farmPlot);
+                    const inProgress = this.settlers.some(s => s.currentTask && s.currentTask.type === TASK_TYPES.HARVEST_CROP && s.currentTask.building === farmPlot);
+                    if (!hasTask && !inProgress) {
+                        this.addHarvestCropTask(farmPlot);
+                    }
+                }
+            }
+
             // Ensure a build task exists for unfinished buildings
             if (building.buildProgress < 100) {
                 const hasTask = this.taskManager.tasks.some(t => t.type === TASK_TYPES.BUILD && t.building === building);

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -192,22 +192,74 @@ export default class UI {
         this.farmPlotMenu = document.createElement('div');
         this.farmPlotMenu.id = 'farm-plot-menu';
         this.farmPlotMenu.style.display = 'none';
-        this.plantWheatButton = document.createElement('button');
-        this.plantWheatButton.textContent = 'Plant wheat';
-        this.plantWheatButton.onclick = () => {
+
+        const cropTypeContainer = document.createElement('div');
+        this.wheatRadio = document.createElement('input');
+        this.wheatRadio.type = 'radio';
+        this.wheatRadio.name = 'crop-type';
+        this.wheatRadio.value = RESOURCE_TYPES.WHEAT;
+        const wheatLabel = document.createElement('label');
+        wheatLabel.textContent = 'Wheat';
+        wheatLabel.appendChild(this.wheatRadio);
+
+        this.cottonRadio = document.createElement('input');
+        this.cottonRadio.type = 'radio';
+        this.cottonRadio.name = 'crop-type';
+        this.cottonRadio.value = RESOURCE_TYPES.COTTON;
+        const cottonLabel = document.createElement('label');
+        cottonLabel.textContent = 'Cotton';
+        cottonLabel.appendChild(this.cottonRadio);
+
+        cropTypeContainer.appendChild(wheatLabel);
+        cropTypeContainer.appendChild(cottonLabel);
+        this.farmPlotMenu.appendChild(cropTypeContainer);
+
+        this.autoSowCheckbox = document.createElement('input');
+        this.autoSowCheckbox.type = 'checkbox';
+        const autoSowLabel = document.createElement('label');
+        autoSowLabel.textContent = 'Auto-sow';
+        autoSowLabel.appendChild(this.autoSowCheckbox);
+        this.farmPlotMenu.appendChild(autoSowLabel);
+        this.autoSowCheckbox.addEventListener('change', () => {
+            if (this.selectedFarmPlot) {
+                this.selectedFarmPlot.autoSow = this.autoSowCheckbox.checked;
+            }
+        });
+
+        this.autoHarvestCheckbox = document.createElement('input');
+        this.autoHarvestCheckbox.type = 'checkbox';
+        const autoHarvestLabel = document.createElement('label');
+        autoHarvestLabel.textContent = 'Auto-harvest';
+        autoHarvestLabel.appendChild(this.autoHarvestCheckbox);
+        this.farmPlotMenu.appendChild(autoHarvestLabel);
+        this.autoHarvestCheckbox.addEventListener('change', () => {
+            if (this.selectedFarmPlot) {
+                this.selectedFarmPlot.autoHarvest = this.autoHarvestCheckbox.checked;
+            }
+        });
+
+        this.wheatRadio.addEventListener('change', () => {
+            if (this.selectedFarmPlot && this.wheatRadio.checked) {
+                this.selectedFarmPlot.desiredCrop = RESOURCE_TYPES.WHEAT;
+            }
+        });
+        this.cottonRadio.addEventListener('change', () => {
+            if (this.selectedFarmPlot && this.cottonRadio.checked) {
+                this.selectedFarmPlot.desiredCrop = RESOURCE_TYPES.COTTON;
+            }
+        });
+
+        this.sowButton = document.createElement('button');
+        this.sowButton.textContent = 'Sow';
+        this.sowButton.onclick = () => {
             if (this.gameInstance && this.selectedFarmPlot) {
-                this.gameInstance.addSowCropTask(this.selectedFarmPlot, RESOURCE_TYPES.WHEAT);
+                const cropType = this.wheatRadio.checked ? RESOURCE_TYPES.WHEAT : RESOURCE_TYPES.COTTON;
+                this.selectedFarmPlot.desiredCrop = cropType;
+                this.gameInstance.addSowCropTask(this.selectedFarmPlot, cropType);
             }
             this.hideFarmPlotMenu();
         };
-        this.plantCottonButton = document.createElement('button');
-        this.plantCottonButton.textContent = 'Plant cotton';
-        this.plantCottonButton.onclick = () => {
-            if (this.gameInstance && this.selectedFarmPlot) {
-                this.gameInstance.addSowCropTask(this.selectedFarmPlot, RESOURCE_TYPES.COTTON);
-            }
-            this.hideFarmPlotMenu();
-        };
+
         this.harvestButton = document.createElement('button');
         this.harvestButton.textContent = 'Harvest';
         this.harvestButton.onclick = () => {
@@ -216,8 +268,8 @@ export default class UI {
             }
             this.hideFarmPlotMenu();
         };
-        this.farmPlotMenu.appendChild(this.plantWheatButton);
-        this.farmPlotMenu.appendChild(this.plantCottonButton);
+
+        this.farmPlotMenu.appendChild(this.sowButton);
         this.farmPlotMenu.appendChild(this.harvestButton);
         this.farmPlotMenu.addEventListener('mousedown', event => event.stopPropagation());
         this.farmPlotMenu.addEventListener('click', event => event.stopPropagation());
@@ -398,8 +450,11 @@ export default class UI {
         this.selectedFarmPlot = farmPlot;
         this.farmPlotMenu.style.left = `${screenX}px`;
         this.farmPlotMenu.style.top = `${screenY}px`;
-        this.plantWheatButton.disabled = farmPlot.crop !== null;
-        this.plantCottonButton.disabled = farmPlot.crop !== null;
+        this.wheatRadio.checked = farmPlot.desiredCrop === RESOURCE_TYPES.WHEAT;
+        this.cottonRadio.checked = farmPlot.desiredCrop === RESOURCE_TYPES.COTTON;
+        this.autoSowCheckbox.checked = farmPlot.autoSow;
+        this.autoHarvestCheckbox.checked = farmPlot.autoHarvest;
+        this.sowButton.disabled = farmPlot.crop !== null;
         this.harvestButton.disabled = farmPlot.growthStage !== 3;
         this.farmPlotMenu.style.display = 'block';
     }


### PR DESCRIPTION
## Summary
- add autoSow, autoHarvest and desiredCrop properties to `FarmPlot`
- overhaul farm plot UI with radio buttons and auto options
- create sow/harvest tasks automatically when auto options enabled
- update tests for new UI and farm plot behaviour

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688611b39f5083238cdd6da067e9f725