### PR TITLE
Add crafting station menu with bandage recipe

### DIFF
--- a/__tests__/CraftingStation.test.js
+++ b/__tests__/CraftingStation.test.js
@@ -15,7 +15,9 @@ describe('CraftingStation', () => {
         expect(craftingStation.type).toBe('crafting_station');
         expect(craftingStation.x).toBe(0);
         expect(craftingStation.y).toBe(0);
-        expect(craftingStation.recipes).toEqual([expect.any(Recipe), expect.any(Recipe)]);
+        expect(craftingStation.recipes).toEqual([expect.any(Recipe)]);
+        expect(craftingStation.autoCraft).toBe(false);
+        expect(craftingStation.desiredRecipe).toBe(null);
     });
 
     test('should add a recipe', () => {

--- a/__tests__/UI.test.js
+++ b/__tests__/UI.test.js
@@ -51,4 +51,17 @@ describe('UI tooltips', () => {
         ui.hideFarmPlotMenu();
         expect(ui.farmPlotMenu.style.display).toBe('none');
     });
+
+    test('crafting station menu shows with recipe list', () => {
+        const ui = new UI({});
+        const mockGame = { addCraftTask: jest.fn() };
+        ui.setGameInstance(mockGame);
+        const station = { recipes: [{ name: 'bandage' }], autoCraft: false };
+        ui.showCraftingStationMenu(station, 5, 5);
+        expect(ui.craftingStationMenu.style.display).toBe('block');
+        expect(ui.recipeSelect.options.length).toBe(1);
+        expect(ui.autoCraftCheckbox.checked).toBe(false);
+        ui.hideCraftingStationMenu();
+        expect(ui.craftingStationMenu.style.display).toBe('none');
+    });
 });

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -102,6 +102,15 @@ canvas {
     z-index: 1000;
 }
 
+#crafting-station-menu {
+    position: absolute;
+    background-color: rgba(0, 0, 0, 0.7);
+    padding: 10px;
+    border-radius: 5px;
+    display: none;
+    z-index: 1000;
+}
+
 .priority-label {
     margin-right: 10px;
 }

--- a/src/js/craftingStation.js
+++ b/src/js/craftingStation.js
@@ -6,10 +6,24 @@ export default class CraftingStation extends Building {
     constructor(x, y) {
         super("crafting_station", x, y, 1, 1, RESOURCE_TYPES.WOOD, 0);
         this.recipes = []; // List of recipes this station can craft
+        this.autoCraft = false;
+        this.desiredRecipe = null;
 
-        // Add example recipes
-        this.addRecipe(new Recipe("plank_from_wood", [{ resourceType: RESOURCE_TYPES.WOOD, quantity: 1 }], [{ resourceType: RESOURCE_TYPES.PLANK, quantity: 1, quality: 1 }], 5));
-        this.addRecipe(new Recipe("block_from_stone", [{ resourceType: RESOURCE_TYPES.STONE, quantity: 1 }], [{ resourceType: RESOURCE_TYPES.BLOCK, quantity: 1, quality: 1 }], 7));
+        // Default recipe: Bandage from cotton
+        this.addRecipe(
+            new Recipe(
+                "bandage",
+                [{ resourceType: RESOURCE_TYPES.COTTON, quantity: 1 }],
+                [
+                    {
+                        resourceType: RESOURCE_TYPES.BANDAGE,
+                        quantity: 1,
+                        quality: 1,
+                    },
+                ],
+                3,
+            ),
+        );
     }
 
     addRecipe(recipe) {

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -276,6 +276,57 @@ export default class UI {
         document.addEventListener('click', () => this.hideFarmPlotMenu());
         document.body.appendChild(this.farmPlotMenu);
 
+        // Crafting station menu
+        this.craftingStationMenu = document.createElement('div');
+        this.craftingStationMenu.id = 'crafting-station-menu';
+        this.craftingStationMenu.style.display = 'none';
+
+        this.recipeSelect = document.createElement('select');
+        this.craftingStationMenu.appendChild(this.recipeSelect);
+
+        this.quantityInput = document.createElement('input');
+        this.quantityInput.type = 'number';
+        this.quantityInput.min = '1';
+        this.quantityInput.value = '1';
+        this.craftingStationMenu.appendChild(this.quantityInput);
+
+        this.autoCraftCheckbox = document.createElement('input');
+        this.autoCraftCheckbox.type = 'checkbox';
+        const autoCraftLabel = document.createElement('label');
+        autoCraftLabel.textContent = 'Auto-craft';
+        autoCraftLabel.appendChild(this.autoCraftCheckbox);
+        this.craftingStationMenu.appendChild(autoCraftLabel);
+
+        this.craftButton = document.createElement('button');
+        this.craftButton.textContent = 'Craft';
+        this.craftButton.onclick = () => {
+            if (this.gameInstance && this.selectedCraftingStation) {
+                const recipe = this.selectedCraftingStation.recipes[this.recipeSelect.selectedIndex];
+                this.selectedCraftingStation.desiredRecipe = recipe;
+                const qty = parseInt(this.quantityInput.value, 10) || 1;
+                this.gameInstance.addCraftTask(this.selectedCraftingStation, recipe, qty);
+                if (this.autoCraftCheckbox.checked) {
+                    this.selectedCraftingStation.autoCraft = true;
+                }
+            }
+            this.hideCraftingStationMenu();
+        };
+        this.craftingStationMenu.appendChild(this.craftButton);
+
+        this.autoCraftCheckbox.addEventListener('change', () => {
+            if (this.selectedCraftingStation) {
+                this.selectedCraftingStation.autoCraft = this.autoCraftCheckbox.checked;
+                if (this.autoCraftCheckbox.checked) {
+                    this.selectedCraftingStation.desiredRecipe = this.selectedCraftingStation.recipes[this.recipeSelect.selectedIndex];
+                }
+            }
+        });
+
+        this.craftingStationMenu.addEventListener('mousedown', event => event.stopPropagation());
+        this.craftingStationMenu.addEventListener('click', event => event.stopPropagation());
+        document.addEventListener('click', () => this.hideCraftingStationMenu());
+        document.body.appendChild(this.craftingStationMenu);
+
         this.tooltip = document.createElement('div');
         this.tooltip.id = 'tooltip';
         document.body.appendChild(this.tooltip);
@@ -462,5 +513,27 @@ export default class UI {
     hideFarmPlotMenu() {
         this.farmPlotMenu.style.display = 'none';
         this.selectedFarmPlot = null;
+    }
+
+    showCraftingStationMenu(station, screenX, screenY) {
+        this.selectedCraftingStation = station;
+        this.recipeSelect.innerHTML = '';
+        station.recipes.forEach((recipe, index) => {
+            const option = document.createElement('option');
+            option.value = index;
+            option.textContent = recipe.name;
+            this.recipeSelect.appendChild(option);
+        });
+        this.recipeSelect.selectedIndex = 0;
+        this.quantityInput.value = '1';
+        this.autoCraftCheckbox.checked = station.autoCraft;
+        this.craftingStationMenu.style.left = `${screenX}px`;
+        this.craftingStationMenu.style.top = `${screenY}px`;
+        this.craftingStationMenu.style.display = 'block';
+    }
+
+    hideCraftingStationMenu() {
+        this.craftingStationMenu.style.display = 'none';
+        this.selectedCraftingStation = null;
     }
 }


### PR DESCRIPTION
## Summary
- implement bandage recipe and auto-craft fields for crafting stations
- support auto crafting in game update loop and handle crafting menu clicks
- provide `addCraftTask` helper in `Game`
- create crafting station menu in UI for manual or automated crafting
- style crafting menu in CSS
- update related tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68861668f5f48323bc7f1e498a53028b