### PR TITLE
Remove empty resource piles automatically

### DIFF
--- a/__tests__/Map.test.js
+++ b/__tests__/Map.test.js
@@ -20,4 +20,13 @@ describe('Map resource piles', () => {
         expect(map.resourcePiles.length).toBe(1);
         expect(map.resourcePiles[0].quantity).toBe(15);
     });
+
+    test('should remove pile when quantity reaches zero', () => {
+        const map = new Map(10, 10, 32, { getSprite: jest.fn() });
+        const pile = new ResourcePile('wood', 5, 3, 3, 32, {});
+        map.addResourcePile(pile);
+        expect(map.resourcePiles.length).toBe(1);
+        pile.remove(5);
+        expect(map.resourcePiles.length).toBe(0);
+    });
 });

--- a/__tests__/ResourcePile.test.js
+++ b/__tests__/ResourcePile.test.js
@@ -11,4 +11,14 @@ describe('ResourcePile', () => {
         const pile = new ResourcePile('stone', 1200, 0, 0, 32, {});
         expect(pile.quantity).toBe(999);
     });
+
+    test('remove should notify map when empty', () => {
+        const mockMap = { removeResourcePile: jest.fn() };
+        const pile = new ResourcePile('wood', 5, 0, 0, 32, {});
+        pile.map = mockMap;
+        const result = pile.remove(5);
+        expect(result).toBe(true);
+        expect(pile.quantity).toBe(0);
+        expect(mockMap.removeResourcePile).toHaveBeenCalledWith(pile);
+    });
 });

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -56,6 +56,7 @@ export default class Map {
 
     addResourcePile(resourcePile) {
         resourcePile.spriteManager = this.spriteManager; // Assign spriteManager to the resource pile
+        resourcePile.map = this;
         const existing = this.resourcePiles.find(p => p.x === resourcePile.x && p.y === resourcePile.y);
         if (existing) {
             if (existing.type === resourcePile.type) {
@@ -68,6 +69,10 @@ export default class Map {
             this.resourcePiles.push(resourcePile);
         }
         return true;
+    }
+
+    removeResourcePile(pile) {
+        this.resourcePiles = this.resourcePiles.filter(p => p !== pile);
     }
 
     addBuilding(building) {
@@ -175,6 +180,7 @@ export default class Map {
         this.resourcePiles = data.resourcePiles.map(pileData => {
             const pile = new ResourcePile(pileData.type, pileData.quantity, pileData.x, pileData.y, this.tileSize, this.spriteManager);
             pile.deserialize(pileData);
+            pile.map = this;
             return pile;
         });
         this.buildings = data.buildings.map(buildingData => {

--- a/src/js/resourcePile.js
+++ b/src/js/resourcePile.js
@@ -11,10 +11,19 @@ export default class ResourcePile extends Resource {
         this.y = y;
         this.tileSize = tileSize;
         this.spriteManager = spriteManager;
+        this.map = null;
     }
 
     add(amount) {
         this.quantity = Math.min(this.quantity + amount, ResourcePile.MAX_QUANTITY);
+    }
+
+    remove(amount) {
+        const success = super.remove(amount);
+        if (success && this.quantity <= 0 && this.map) {
+            this.map.removeResourcePile(this);
+        }
+        return success;
     }
 
     render(ctx) {


### PR DESCRIPTION
## Summary
- delete a resource pile from the map when it runs out of items
- set each resource pile's map when added or loaded
- test the new behaviour for piles and maps

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68862d8944908323bcefb4a0867f370f