### PR TITLE
Fix pause behavior when focus returns

### DIFF
--- a/src/js/game.js
+++ b/src/js/game.js
@@ -119,9 +119,8 @@ export default class Game {
         document.addEventListener('visibilitychange', () => {
             if (document.hidden) {
                 this.pause();
-            } else {
-                this.resume();
             }
+            // Do not automatically resume when focus returns; player must unpause manually
         });
         this.gameLoop(0);
     }


### PR DESCRIPTION
## Summary
- avoid resuming game automatically when tab regains focus

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688632e2711883238b3a36541e5c371c