### PR TITLE
Use sprites for crafting station and table

### DIFF
--- a/__tests__/CraftingStation.test.js
+++ b/__tests__/CraftingStation.test.js
@@ -1,5 +1,6 @@
 import CraftingStation from '../src/js/craftingStation.js';
 import Recipe from '../src/js/recipe.js';
+import SpriteManager from '../src/js/spriteManager.js';
 
 
 jest.mock('../src/js/recipe.js');
@@ -8,7 +9,7 @@ describe('CraftingStation', () => {
     let craftingStation;
 
     beforeEach(() => {
-        craftingStation = new CraftingStation(0, 0);
+        craftingStation = new CraftingStation(0, 0, new SpriteManager());
     });
 
     test('should initialize with correct properties', () => {

--- a/src/js/craftingStation.js
+++ b/src/js/craftingStation.js
@@ -3,8 +3,10 @@ import Recipe from './recipe.js';
 import { RESOURCE_TYPES } from './constants.js';
 
 export default class CraftingStation extends Building {
-    constructor(x, y) {
+    constructor(x, y, spriteManager = null) {
         super("crafting_station", x, y, 1, 1, RESOURCE_TYPES.WOOD, 0);
+        this.spriteManager = spriteManager;
+        this.stationSprite = spriteManager ? spriteManager.getSprite('crafting_station') : null;
         this.recipes = []; // List of recipes this station can craft
         this.autoCraft = false;
         this.desiredRecipe = null;
@@ -38,9 +40,14 @@ export default class CraftingStation extends Building {
 
     render(ctx, tileSize) {
         super.render(ctx, tileSize);
-        ctx.fillStyle = "purple"; // Example color for crafting station
-        ctx.fillRect(this.x * tileSize, this.y * tileSize, this.width * tileSize, this.height * tileSize);
-        ctx.strokeStyle = "black";
-        ctx.strokeRect(this.x * tileSize, this.y * tileSize, this.width * tileSize, this.height * tileSize);
+
+        if (this.buildProgress === 100 && this.stationSprite) {
+            ctx.drawImage(this.stationSprite, this.x * tileSize, this.y * tileSize, tileSize, tileSize);
+        } else {
+            ctx.fillStyle = "purple"; // Example color for crafting station
+            ctx.fillRect(this.x * tileSize, this.y * tileSize, this.width * tileSize, this.height * tileSize);
+            ctx.strokeStyle = "black";
+            ctx.strokeRect(this.x * tileSize, this.y * tileSize, this.width * tileSize, this.height * tileSize);
+        }
     }
 }

--- a/src/js/furniture.js
+++ b/src/js/furniture.js
@@ -1,8 +1,10 @@
 import Building from './building.js';
 
 export default class Furniture extends Building {
-    constructor(type, x, y, width, height, material, health) {
+    constructor(type, x, y, width, height, material, health, spriteManager = null) {
         super(type, x, y, width, height, material, health);
+        this.spriteManager = spriteManager;
+        this.sprite = spriteManager ? spriteManager.getSprite(type) : null;
         this.isFurniture = true;
         if (type === 'bed') {
             this.occupant = null; // Settler currently using the bed
@@ -11,11 +13,16 @@ export default class Furniture extends Building {
 
     render(ctx, tileSize) {
         super.render(ctx, tileSize);
-        // Additional rendering for furniture if needed
-        ctx.fillStyle = 'rgba(139, 69, 19, 0.7)'; // Brown for furniture
-        ctx.fillRect(this.x * tileSize, this.y * tileSize, this.width * tileSize, this.height * tileSize);
-        ctx.fillStyle = 'white';
-        ctx.font = '10px Arial';
-        ctx.fillText(this.type, this.x * tileSize + 5, this.y * tileSize + 15);
+
+        if (this.buildProgress === 100 && this.sprite) {
+            ctx.drawImage(this.sprite, this.x * tileSize, this.y * tileSize, tileSize, tileSize);
+        } else {
+            // Additional rendering for furniture if needed
+            ctx.fillStyle = 'rgba(139, 69, 19, 0.7)'; // Brown for furniture
+            ctx.fillRect(this.x * tileSize, this.y * tileSize, this.width * tileSize, this.height * tileSize);
+            ctx.fillStyle = 'white';
+            ctx.font = '10px Arial';
+            ctx.fillText(this.type, this.x * tileSize + 5, this.y * tileSize + 15);
+        }
     }
 }

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -95,6 +95,8 @@ export default class Game {
             await this.spriteManager.loadImage('dirt_pile', 'src/assets/dirt_pile.png');
             await this.spriteManager.loadImage('farm_plot', 'src/assets/farmPlot.png');
             await this.spriteManager.loadImage(RESOURCE_TYPES.BANDAGE, 'src/assets/bandage.png');
+            await this.spriteManager.loadImage('crafting_station', 'src/assets/crafting_station.png');
+            await this.spriteManager.loadImage('table', 'src/assets/table.png');
             await this.spriteManager.loadImage('wheat_1', 'src/assets/wheat_1.png');
             await this.spriteManager.loadImage('wheat_2', 'src/assets/wheat_2.png');
             await this.spriteManager.loadImage('wheat_3', 'src/assets/wheat_3.png');
@@ -622,15 +624,15 @@ export default class Game {
             // Place the selected building
             let newBuilding;
             if (this.selectedBuilding === 'crafting_station') {
-                newBuilding = new CraftingStation(tileX, tileY);
+                newBuilding = new CraftingStation(tileX, tileY, this.spriteManager);
             } else if (this.selectedBuilding === 'farm_plot') {
                 newBuilding = new FarmPlot(tileX, tileY, this.spriteManager);
             } else if (this.selectedBuilding === 'animal_pen') {
                 newBuilding = new AnimalPen(tileX, tileY);
             } else if (this.selectedBuilding === 'bed') {
-                newBuilding = new Furniture('bed', tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 50);
+                newBuilding = new Furniture('bed', tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 50, this.spriteManager);
             } else if (this.selectedBuilding === 'table') {
-                newBuilding = new Furniture('table', tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 75);
+                newBuilding = new Furniture('table', tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 75, this.spriteManager);
             } else if (this.selectedBuilding === 'barricade') {
                 newBuilding = new Building('barricade', tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 0); // Barricade is a simple building
             } else if (this.selectedBuilding === 'wall') {

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -187,13 +187,13 @@ export default class Map {
             // Re-instantiate based on type if needed, otherwise use base Building
             let building;
             if (buildingData.type === 'crafting_station') {
-                building = new CraftingStation(buildingData.x, buildingData.y);
+                building = new CraftingStation(buildingData.x, buildingData.y, this.spriteManager);
             } else if (buildingData.type === 'farm_plot') {
-                building = new FarmPlot(buildingData.x, buildingData.y);
+                building = new FarmPlot(buildingData.x, buildingData.y, this.spriteManager);
             } else if (buildingData.type === 'animal_pen') {
                 building = new AnimalPen(buildingData.x, buildingData.y);
             } else if (buildingData.type === 'bed' || buildingData.type === 'table') {
-                building = new Furniture(buildingData.type, buildingData.x, buildingData.y, 1, 1, buildingData.material, buildingData.health);
+                building = new Furniture(buildingData.type, buildingData.x, buildingData.y, 1, 1, buildingData.material, buildingData.health, this.spriteManager);
             } else {
                 building = new Building(buildingData.type, buildingData.x, buildingData.y, buildingData.width, buildingData.height, buildingData.material, buildingData.health);
             }


### PR DESCRIPTION
## Summary
- load `crafting_station.png` and `table.png`
- draw crafting stations and tables with their sprites
- pass sprite manager to buildings when constructing them
- adjust map deserialization for new parameters
- update CraftingStation tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68863462b5448323bd8510f112c65e9d