### PR TITLE
Add pause overlay to game

### DIFF
--- a/__tests__/Game.test.js
+++ b/__tests__/Game.test.js
@@ -340,14 +340,14 @@ describe('Game', () => {
         expect(game.isPaused).toBe(false);
     });
 
-    test('gameLoop skips update and render when paused', () => {
+    test('gameLoop skips update but still renders when paused', () => {
         global.requestAnimationFrame = jest.fn();
         const updateSpy = jest.spyOn(game, 'update').mockImplementation(() => {});
         const renderSpy = jest.spyOn(game, 'render').mockImplementation(() => {});
         game.pause();
         game.gameLoop(16);
         expect(updateSpy).not.toHaveBeenCalled();
-        expect(renderSpy).not.toHaveBeenCalled();
+        expect(renderSpy).toHaveBeenCalled();
         expect(global.requestAnimationFrame).toHaveBeenCalled();
         updateSpy.mockRestore();
         renderSpy.mockRestore();

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -299,7 +299,7 @@ export default class Game {
         this.map.render(this.ctx);
         this.roomManager.render(this.ctx, this.map.tileSize);
 
-        
+
 
         // Render settlers
         this.settlers.forEach(settler => {
@@ -312,6 +312,24 @@ export default class Game {
         });
 
         this.camera.resetTransform();
+
+        if (this.isPaused) {
+            this.drawPauseOverlay();
+        }
+    }
+
+    drawPauseOverlay() {
+        this.ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
+        this.ctx.fillRect(0, 0, this.ctx.canvas.width, this.ctx.canvas.height);
+        this.ctx.fillStyle = 'white';
+        this.ctx.font = 'bold 48px Arial';
+        this.ctx.textAlign = 'center';
+        this.ctx.textBaseline = 'middle';
+        const centerX = this.ctx.canvas.width / 2;
+        const centerY = this.ctx.canvas.height / 2;
+        this.ctx.fillText('Paused', centerX, centerY - 20);
+        this.ctx.font = '24px Arial';
+        this.ctx.fillText('press p to unpause', centerX, centerY + 20);
     }
 
     gameLoop(timestamp) {
@@ -320,8 +338,8 @@ export default class Game {
 
         if (!this.isPaused) {
             this.update(deltaTime);
-            this.render();
         }
+        this.render();
 
         requestAnimationFrame(this.gameLoop);
     }


### PR DESCRIPTION
## Summary
- render half-transparent pause overlay with instructions
- always render frame in game loop when paused
- update tests for new pause behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688634deb92483238eb2114a754333f1