### PR TITLE
Improve building rendering

### DIFF
--- a/src/js/building.js
+++ b/src/js/building.js
@@ -67,16 +67,29 @@ export default class Building {
     }
 
     render(ctx, tileSize) {
+        const x = this.x * tileSize;
+        const y = this.y * tileSize;
+        const width = this.width * tileSize;
+        const height = this.height * tileSize;
+
         if (this.buildProgress < 100) {
-            ctx.fillStyle = `rgba(169, 169, 169, ${this.buildProgress / 100})`; // Grey, transparent based on progress
-        } else {
-            // Render based on health
-            const healthOpacity = this.health / this.maxHealth;
-            ctx.fillStyle = this.material === RESOURCE_TYPES.WOOD ? `rgba(139, 69, 19, ${healthOpacity})` : `rgba(128, 128, 128, ${healthOpacity})`;
+            ctx.fillStyle = `rgba(169, 169, 169, ${this.buildProgress / 100})`;
+            ctx.fillRect(x, y, width, height);
+            ctx.strokeStyle = 'black';
+            ctx.strokeRect(x, y, width, height);
+            return;
         }
-        ctx.fillRect(this.x * tileSize, this.y * tileSize, this.width * tileSize, this.height * tileSize);
-        ctx.strokeStyle = "black";
-        ctx.strokeRect(this.x * tileSize, this.y * tileSize, this.width * tileSize, this.height * tileSize);
+
+        if (this.drawBase !== false) {
+            const inset = tileSize * 0.1;
+            const healthOpacity = this.health / this.maxHealth;
+            ctx.fillStyle = this.material === RESOURCE_TYPES.WOOD ?
+                `rgba(139, 69, 19, ${healthOpacity})` :
+                `rgba(128, 128, 128, ${healthOpacity})`;
+            ctx.fillRect(x + inset, y + inset, width - inset * 2, height - inset * 2);
+            ctx.strokeStyle = 'black';
+            ctx.strokeRect(x + inset, y + inset, width - inset * 2, height - inset * 2);
+        }
     }
 
     serialize() {

--- a/src/js/craftingStation.js
+++ b/src/js/craftingStation.js
@@ -5,6 +5,7 @@ import { RESOURCE_TYPES } from './constants.js';
 export default class CraftingStation extends Building {
     constructor(x, y, spriteManager = null) {
         super("crafting_station", x, y, 1, 1, RESOURCE_TYPES.WOOD, 0);
+        this.drawBase = false;
         this.spriteManager = spriteManager;
         this.stationSprite = spriteManager ? spriteManager.getSprite('crafting_station') : null;
         this.recipes = []; // List of recipes this station can craft

--- a/src/js/farmPlot.js
+++ b/src/js/farmPlot.js
@@ -6,6 +6,7 @@ export default class FarmPlot extends Building {
     constructor(x, y, spriteManager) {
         // Farm plots require no construction materials
         super('farm_plot', x, y, 1, 1, null, 0, 0);
+        this.drawBase = false;
         this.crop = null; // What is planted (e.g., 'wheat')
         this.growthStage = 0; // 0: empty, 1: planted, 2: growing, 3: mature
         this.growthRate = 0.01; // How fast it grows per game tick

--- a/src/js/furniture.js
+++ b/src/js/furniture.js
@@ -3,6 +3,7 @@ import Building from './building.js';
 export default class Furniture extends Building {
     constructor(type, x, y, width, height, material, health, spriteManager = null) {
         super(type, x, y, width, height, material, health);
+        this.drawBase = false;
         this.spriteManager = spriteManager;
         this.sprite = spriteManager ? spriteManager.getSprite(type) : null;
         this.isFurniture = true;
@@ -16,10 +17,10 @@ export default class Furniture extends Building {
 
         if (this.buildProgress === 100 && this.sprite) {
             ctx.drawImage(this.sprite, this.x * tileSize, this.y * tileSize, tileSize, tileSize);
-        } else {
-            // Additional rendering for furniture if needed
-            ctx.fillStyle = 'rgba(139, 69, 19, 0.7)'; // Brown for furniture
-            ctx.fillRect(this.x * tileSize, this.y * tileSize, this.width * tileSize, this.height * tileSize);
+        } else if (this.buildProgress === 100) {
+            const inset = tileSize * 0.1;
+            ctx.fillStyle = 'rgba(139, 69, 19, 0.7)';
+            ctx.fillRect(this.x * tileSize + inset, this.y * tileSize + inset, this.width * tileSize - inset * 2, this.height * tileSize - inset * 2);
             ctx.fillStyle = 'white';
             ctx.font = '10px Arial';
             ctx.fillText(this.type, this.x * tileSize + 5, this.y * tileSize + 15);


### PR DESCRIPTION
## Summary
- make building render overlay the ground texture
- suppress brown square for furniture, crafting stations and farm plots
- draw furniture placeholder smaller if sprite missing

## Testing
- `npx eslint .`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688636504048832394d2891ecf90973b