### PR TITLE
Remove bandage drops from hunting

### DIFF
--- a/__tests__/Settler.test.js
+++ b/__tests__/Settler.test.js
@@ -281,7 +281,7 @@ describe('Settler', () => {
         expect(settler.currentTask).toBe(null);
     });
 
-    test('should handle hunt_animal task and drop bandage pile', () => {
+    test('should handle hunt_animal task without dropping bandage pile', () => {
         const task = new Task(TASK_TYPES.HUNT_ANIMAL, 1, 1, 'meat', 0.2);
         settler.currentTask = task;
         settler.x = 1;
@@ -294,9 +294,9 @@ describe('Settler', () => {
 
         expect(mockResourceManager.addResource).not.toHaveBeenCalled();
         expect(settler.map.addResourcePile).toHaveBeenCalled();
-        const bandagePile = settler.map.addResourcePile.mock.calls[0][0];
-        expect(bandagePile.type).toBe('bandage');
-        expect(bandagePile.quantity).toBe(1);
+        const meatPile = settler.map.addResourcePile.mock.calls[0][0];
+        expect(meatPile.type).toBe('meat');
+        expect(meatPile.quantity).toBe(1);
         expect(settler.carrying).toBe(null);
         expect(settler.currentTask).toBe(null);
     });

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -433,11 +433,6 @@ export default class Settler {
 
                     if (this.currentTask.quantity <= 0) {
                         this.pickUpPile(resourceType, 1); // Settler carries the resource
-                        if (this.currentTask.type === TASK_TYPES.HUNT_ANIMAL) {
-                            // Hunting yields extra materials like bandages dropped on the ground
-                            const bandagePile = new ResourcePile(RESOURCE_TYPES.BANDAGE, 1, this.currentTask.targetX, this.currentTask.targetY, this.map.tileSize, this.spriteManager);
-                            this.map.addResourcePile(bandagePile);
-                        }
                         this.map.removeResourceNode(this.currentTask.targetX, this.currentTask.targetY);
                         console.log(`${this.name} completed ${this.currentTask.type} and is now carrying ${this.carrying.type}.`);
                         this.currentTask = null;


### PR DESCRIPTION
## Summary
- stop dropping bandage piles when hunting
- update hunt_animal test for new behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688637883cec83239ff96ad6d9f58b11