### PR TITLE
Fix floor drawing order

### DIFF
--- a/src/js/map.js
+++ b/src/js/map.js
@@ -156,7 +156,22 @@ export default class Map {
             pile.render(ctx);
         }
 
+        // Draw floors first so they appear beneath furniture and other buildings
+        const floors = [];
+        const nonFloors = [];
         for (const building of this.buildings) {
+            if (building.type === 'floor') {
+                floors.push(building);
+            } else {
+                nonFloors.push(building);
+            }
+        }
+
+        for (const floor of floors) {
+            floor.render(ctx, this.tileSize);
+        }
+
+        for (const building of nonFloors) {
             building.render(ctx, this.tileSize);
         }
     }


### PR DESCRIPTION
## Summary
- render floors before other buildings so floors remain underneath furniture and structures

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68863c2d01648323a766e2123906b818