### PR TITLE
Enable building from adjacent tiles

### DIFF
--- a/__tests__/Settler.test.js
+++ b/__tests__/Settler.test.js
@@ -2,6 +2,7 @@ import Settler from '../src/js/settler.js';
 import Task from '../src/js/task.js';
 import { TASK_TYPES, HEALTH_REGEN_RATE } from '../src/js/constants.js';
 import ResourcePile from '../src/js/resourcePile.js';
+import Building from '../src/js/building.js';
 
 jest.mock('../src/js/resourceManager.js');
 jest.mock('../src/js/map.js');
@@ -540,6 +541,22 @@ describe('Settler', () => {
 
         expect(settler.isSleeping).toBe(false);
         expect(settler.state).toBe('combat');
+    });
+
+    test('settler can build from diagonal tile', () => {
+        const building = new Building('wall', 1, 1, 1, 1, 'wood', 0, 1);
+        mockMap.buildings = [building];
+        settler.x = 0;
+        settler.y = 0;
+        settler.carrying = { type: 'wood', quantity: 1 };
+        settler.currentTask = new Task(TASK_TYPES.BUILD, building.x, building.y, null, 100, 2, building);
+
+        settler.updateNeeds(3000);
+
+        expect(building.resourcesDelivered).toBe(1);
+        expect(building.buildProgress).toBeGreaterThan(0);
+        expect(Math.floor(settler.x)).not.toBe(building.x);
+        expect(Math.floor(settler.y)).not.toBe(building.y);
     });
 
     test('health regenerates based on hunger level', () => {

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -116,6 +116,17 @@ export default class Settler {
         }
     }
 
+    isAdjacentToBuilding(building) {
+        const sx = Math.floor(this.x);
+        const sy = Math.floor(this.y);
+        return (
+            sx >= building.x - 1 &&
+            sx <= building.x + building.width &&
+            sy >= building.y - 1 &&
+            sy <= building.y + building.height
+        );
+    }
+
     updateNeeds(deltaTime) {
         if (this.isDead) return; // Do nothing if dead
         // Decrease hunger over time
@@ -282,9 +293,19 @@ export default class Settler {
             }
 
             // Check if arrived at target
-            if (Math.abs(this.x - this.currentTask.targetX) < speed && Math.abs(this.y - this.currentTask.targetY) < speed) {
-                this.x = this.currentTask.targetX; // Snap to tile
-                this.y = this.currentTask.targetY; // Snap to tile
+            const arrived = this.currentTask.type === TASK_TYPES.BUILD && this.currentTask.building
+                ? this.isAdjacentToBuilding(this.currentTask.building)
+                : Math.abs(this.x - this.currentTask.targetX) < speed && Math.abs(this.y - this.currentTask.targetY) < speed;
+            if (arrived) {
+                if (this.currentTask.type !== TASK_TYPES.BUILD) {
+                    this.x = this.currentTask.targetX; // Snap to tile
+                    this.y = this.currentTask.targetY; // Snap to tile
+                } else {
+                    this.x = Math.round(this.x);
+                    this.y = Math.round(this.y);
+                    this.currentTask.targetX = this.x;
+                    this.currentTask.targetY = this.y;
+                }
 
                 if (this.currentTask.type === "move") {
                     console.log(`${this.name} completed task: ${this.currentTask.type}`);


### PR DESCRIPTION
## Summary
- allow settlers to build when positioned on any neighboring tile, including diagonals
- add helper `isAdjacentToBuilding`
- test building from a diagonal tile

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68865af21e1083238cfb270f3bf82542