### PR TITLE
Add water puddles to map

### DIFF
--- a/__tests__/Map.test.js
+++ b/__tests__/Map.test.js
@@ -29,4 +29,30 @@ describe('Map resource piles', () => {
         pile.remove(5);
         expect(map.resourcePiles.length).toBe(0);
     });
+
+    test('should create clusters of water tiles', () => {
+        const map = new Map(50, 30, 32, { getSprite: jest.fn() });
+        const waterTiles = [];
+        for (let y = 0; y < map.height; y++) {
+            for (let x = 0; x < map.width; x++) {
+                if (map.tiles[y][x] === 8) {
+                    waterTiles.push({ x, y });
+                }
+            }
+        }
+        expect(waterTiles.length).toBeGreaterThan(0);
+        const hasCluster = waterTiles.some(tile => {
+            const { x, y } = tile;
+            const neighbors = [
+                [x + 1, y],
+                [x - 1, y],
+                [x, y + 1],
+                [x, y - 1],
+            ];
+            return neighbors.some(([nx, ny]) =>
+                nx >= 0 && nx < map.width && ny >= 0 && ny < map.height && map.tiles[ny][nx] === 8
+            );
+        });
+        expect(hasCluster).toBe(true);
+    });
 });

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -77,6 +77,7 @@ export default class Game {
             await this.spriteManager.loadImage('settler', 'src/assets/settler.png');
             await this.spriteManager.loadImage('tree', 'src/assets/tree.png');
             await this.spriteManager.loadImage('grass', 'src/assets/grass.png');
+            await this.spriteManager.loadImage('water', 'src/assets/water.png');
             await this.spriteManager.loadImage('berry_bush', 'src/assets/berry_bush.png');
             await this.spriteManager.loadImage('goblin', 'src/assets/goblin.png');
             await this.spriteManager.loadImage(RESOURCE_TYPES.STONE, 'src/assets/stone.png');

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -53,7 +53,7 @@ export default class Map {
             }
         }
 
-        const puddleChance = 0.01;
+        const puddleChance = 0.005;
         for (let y = 0; y < this.height; y++) {
             for (let x = 0; x < this.width; x++) {
                 if (Math.random() < puddleChance) {

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -22,7 +22,8 @@ export default class Map {
             4: '#FF0000', // berries
             5: '#A9A9A9', // iron ore
             6: '#8B4513', // wild food
-            7: '#800000'  // animal
+            7: '#800000', // animal
+            8: '#0000FF'  // water
         };
     }
 
@@ -51,6 +52,26 @@ export default class Map {
                 }
             }
         }
+
+        const puddleChance = 0.01;
+        for (let y = 0; y < this.height; y++) {
+            for (let x = 0; x < this.width; x++) {
+                if (Math.random() < puddleChance) {
+                    const patchWidth = Math.floor(Math.random() * 2) + 2; // 2-3
+                    const patchHeight = Math.floor(Math.random() * 2) + 2; // 2-3
+                    for (let py = 0; py < patchHeight; py++) {
+                        for (let px = 0; px < patchWidth; px++) {
+                            const nx = x + px;
+                            const ny = y + py;
+                            if (nx < this.width && ny < this.height) {
+                                tiles[ny][nx] = 8; // water tile
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         return tiles;
     }
 
@@ -119,6 +140,7 @@ export default class Map {
         const deerSprite = this.spriteManager.getSprite('deer');
         const dirtSprite = this.spriteManager.getSprite('dirt');
         const forageFoodSprite = this.spriteManager.getSprite('mushroom');
+        const waterSprite = this.spriteManager.getSprite('water');
 
         for (let y = 0; y < this.height; y++) {
             for (let x = 0; x < this.width; x++) {
@@ -145,6 +167,8 @@ export default class Map {
                     ctx.drawImage(dirtSprite, x * this.tileSize, y * this.tileSize, this.tileSize, this.tileSize);
                 } else if (tile === 6 && forageFoodSprite) {
                     ctx.drawImage(forageFoodSprite, x * this.tileSize, y * this.tileSize, this.tileSize, this.tileSize);
+                } else if (tile === 8 && waterSprite) {
+                    ctx.drawImage(waterSprite, x * this.tileSize, y * this.tileSize, this.tileSize, this.tileSize);
                 } else if (tile !== 0) {
                     ctx.fillStyle = this.tileColors[tile] || '#000000';
                     ctx.fillRect(x * this.tileSize, y * this.tileSize, this.tileSize, this.tileSize);


### PR DESCRIPTION
## Summary
- generate small water patches when creating maps
- render water tiles using the water sprite
- load water.png in game startup
- test that water tiles are generated in clusters

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68865b65e808832399d3bc410582e8c6