### PR TITLE
Allow building from neighboring tiles

### DIFF
--- a/__tests__/Game.test.js
+++ b/__tests__/Game.test.js
@@ -115,12 +115,12 @@ describe('Game', () => {
     });
 
     test('handleClick should place a building when in build mode', () => {
-        game.toggleBuildMode('wall');
-        game.handleClick({ clientX: 100, clientY: 100, target: { closest: () => null } });
-
         // Calculate expected tile coordinates based on mock canvas size and default camera
         const expectedTileX = Math.floor(((100 - mockCtx.canvas.width / 2) / game.camera.zoom + game.camera.x) / game.map.tileSize);
         const expectedTileY = Math.floor(((100 - mockCtx.canvas.height / 2) / game.camera.zoom + game.camera.y) / game.map.tileSize);
+        game.map.findAdjacentFreeTile = jest.fn().mockReturnValue({ x: expectedTileX + 1, y: expectedTileY });
+        game.toggleBuildMode('wall');
+        game.handleClick({ clientX: 100, clientY: 100, target: { closest: () => null } });
 
         expect(game.map.addBuilding).toHaveBeenCalledTimes(1);
         expect(game.map.addBuilding).toHaveBeenCalledWith(expect.any(Object));
@@ -138,7 +138,7 @@ describe('Game', () => {
         expect(game.taskManager.addTask).toHaveBeenCalledTimes(2);
         expect(Task).toHaveBeenCalledWith(
             TASK_TYPES.BUILD,
-            expectedTileX,
+            expectedTileX + 1,
             expectedTileY,
             null,
             100,
@@ -153,11 +153,11 @@ describe('Game', () => {
     });
 
     test('handleClick should not create haul task for farm plot', () => {
-        game.toggleBuildMode('farm_plot');
-        game.handleClick({ clientX: 100, clientY: 100, target: { closest: () => null } });
-
         const expectedTileX = Math.floor(((100 - mockCtx.canvas.width / 2) / game.camera.zoom + game.camera.x) / game.map.tileSize);
         const expectedTileY = Math.floor(((100 - mockCtx.canvas.height / 2) / game.camera.zoom + game.camera.y) / game.map.tileSize);
+        game.map.findAdjacentFreeTile = jest.fn().mockReturnValue({ x: expectedTileX + 1, y: expectedTileY });
+        game.toggleBuildMode('farm_plot');
+        game.handleClick({ clientX: 100, clientY: 100, target: { closest: () => null } });
 
         expect(game.map.addBuilding).toHaveBeenCalledTimes(1);
         expect(game.map.addBuilding).toHaveBeenCalledWith(expect.any(Object));
@@ -175,6 +175,8 @@ describe('Game', () => {
         expect(game.taskManager.addTask).toHaveBeenCalledTimes(1);
         const buildTask = game.taskManager.addTask.mock.calls[0][0];
         expect(buildTask.type).toBe(TASK_TYPES.BUILD);
+        expect(buildTask.targetX).toBe(expectedTileX + 1);
+        expect(buildTask.targetY).toBe(expectedTileY);
     });
 
     test('handleClick should not place a building when not in build mode', () => {

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -270,11 +270,15 @@ export default class Game {
                             s.currentTask.building === building,
                     );
                     if (!hasTask && !inProgress) {
+                        const buildPos = this.map.findAdjacentFreeTile(
+                            building.x,
+                            building.y,
+                        );
                         this.taskManager.addTask(
                             new Task(
                                 TASK_TYPES.BUILD,
-                                building.x,
-                                building.y,
+                                buildPos.x,
+                                buildPos.y,
                                 null,
                                 100,
                                 2,
@@ -679,7 +683,18 @@ export default class Game {
                 );
             }
             // Build task has lower priority so it begins once resources arrive (if any)
-            this.taskManager.addTask(new Task(TASK_TYPES.BUILD, tileX, tileY, null, 100, 2, newBuilding));
+            const buildPos = this.map.findAdjacentFreeTile(tileX, tileY);
+            this.taskManager.addTask(
+                new Task(
+                    TASK_TYPES.BUILD,
+                    buildPos.x,
+                    buildPos.y,
+                    null,
+                    100,
+                    2,
+                    newBuilding,
+                ),
+            );
             this.soundManager.play('action');
             this.buildMode = false; // Exit build mode after placing
             this.selectedBuilding = null;

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -131,6 +131,32 @@ export default class Map {
         return this.buildings;
     }
 
+    findAdjacentFreeTile(x, y) {
+        const directions = [
+            { dx: 1, dy: 0 },
+            { dx: -1, dy: 0 },
+            { dx: 0, dy: 1 },
+            { dx: 0, dy: -1 },
+        ];
+
+        for (const { dx, dy } of directions) {
+            const nx = x + dx;
+            const ny = y + dy;
+            if (
+                nx >= 0 &&
+                nx < this.width &&
+                ny >= 0 &&
+                ny < this.height &&
+                this.getTile(nx, ny) !== 8 &&
+                !this.getBuildingAt(nx, ny)
+            ) {
+                return { x: nx, y: ny };
+            }
+        }
+
+        return { x, y };
+    }
+
     render(ctx) {
         const treeSprite = this.spriteManager.getSprite('tree');
         const grassSprite = this.spriteManager.getSprite('grass');

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -131,13 +131,16 @@ export default class Map {
         return this.buildings;
     }
 
-    findAdjacentFreeTile(x, y) {
+    findAdjacentFreeTile(x, y, fromX = null, fromY = null) {
         const directions = [
             { dx: 1, dy: 0 },
             { dx: -1, dy: 0 },
             { dx: 0, dy: 1 },
             { dx: 0, dy: -1 },
         ];
+
+        let best = null;
+        let bestDist = Infinity;
 
         for (const { dx, dy } of directions) {
             const nx = x + dx;
@@ -150,10 +153,19 @@ export default class Map {
                 this.getTile(nx, ny) !== 8 &&
                 !this.getBuildingAt(nx, ny)
             ) {
-                return { x: nx, y: ny };
+                if (fromX !== null && fromY !== null) {
+                    const dist = (fromX - nx) ** 2 + (fromY - ny) ** 2;
+                    if (dist < bestDist) {
+                        bestDist = dist;
+                        best = { x: nx, y: ny };
+                    }
+                } else {
+                    return { x: nx, y: ny };
+                }
             }
         }
 
+        if (best) return best;
         return { x, y };
     }
 

--- a/src/js/taskManager.js
+++ b/src/js/taskManager.js
@@ -80,6 +80,16 @@ export default class TaskManager {
             });
 
             if (bestSettler) {
+                if (task.type === TASK_TYPES.BUILD && task.building) {
+                    const pos = bestSettler.map.findAdjacentFreeTile(
+                        task.building.x,
+                        task.building.y,
+                        bestSettler.x,
+                        bestSettler.y,
+                    );
+                    task.targetX = pos.x;
+                    task.targetY = pos.y;
+                }
                 if (bestSettler.currentBuilding && bestSettler.currentBuilding !== task.building) {
                     bestSettler.currentBuilding.occupant = null;
                     bestSettler.currentBuilding = null;


### PR DESCRIPTION
## Summary
- add `findAdjacentFreeTile` helper to map
- set build tasks to use an adjacent tile
- adjust game logic and tests for new build behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68865f474fc48323b5ace45fd474e232