### PR TITLE
Fix pile text scaling after tab focus changes

### DIFF
--- a/src/js/resourcePile.js
+++ b/src/js/resourcePile.js
@@ -63,6 +63,7 @@ export default class ResourcePile extends Resource {
             ctx.fillRect(this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
         }
         ctx.fillStyle = 'white';
+        ctx.font = '10px Arial';
         ctx.fillText(this.quantity, this.x * this.tileSize + 5, this.y * this.tileSize + this.tileSize / 2);
     }
 


### PR DESCRIPTION
## Summary
- ensure consistent font when rendering resource piles

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688660075b5c832399241969d9c77067