### PR TITLE
Add blocking building types

### DIFF
--- a/__tests__/Building.test.js
+++ b/__tests__/Building.test.js
@@ -1,10 +1,11 @@
 import Building from '../src/js/building.js';
+import { BUILDING_TYPES } from '../src/js/constants.js';
 
 import Map from '../src/js/map.js';
 
 describe('Building', () => {
     test('takeDamage reduces health and does not go below zero', () => {
-        const building = new Building('barricade', 0, 0, 1, 1, 'wood', 100);
+        const building = new Building(BUILDING_TYPES.BARRICADE, 0, 0, 1, 1, 'wood', 100);
         building.takeDamage(30);
         expect(building.health).toBe(70);
         building.takeDamage(100);
@@ -13,7 +14,7 @@ describe('Building', () => {
 
     test('spillInventory drops resources as piles', () => {
         const map = new Map(10, 10, 32, { getSprite: jest.fn() });
-        const building = new Building('wall', 1, 1, 1, 1, 'wood', 0, 5);
+        const building = new Building(BUILDING_TYPES.WALL, 1, 1, 1, 1, 'wood', 0, 5);
         building.addToInventory('wood', 5);
         map.addBuilding(building);
 

--- a/__tests__/Game.test.js
+++ b/__tests__/Game.test.js
@@ -5,6 +5,7 @@ import ResourceManager from '../src/js/resourceManager.js';
 import Settler from '../src/js/settler.js';
 import TaskManager from '../src/js/taskManager.js';
 import Building from '../src/js/building.js';
+import { BUILDING_TYPES } from '../src/js/constants.js';
 import Task from '../src/js/task.js';
 import { TASK_TYPES } from '../src/js/constants.js';
 
@@ -126,7 +127,7 @@ describe('Game', () => {
         expect(game.map.addBuilding).toHaveBeenCalledWith(expect.any(Object));
         // Verify the Building constructor was called with correct arguments
         expect(Building).toHaveBeenCalledWith(
-            'wall',
+            BUILDING_TYPES.WALL,
             expectedTileX,
             expectedTileY,
             1,
@@ -162,7 +163,7 @@ describe('Game', () => {
         expect(game.map.addBuilding).toHaveBeenCalledTimes(1);
         expect(game.map.addBuilding).toHaveBeenCalledWith(expect.any(Object));
         expect(Building).toHaveBeenCalledWith(
-            'farm_plot',
+            BUILDING_TYPES.FARM_PLOT,
             expectedTileX,
             expectedTileY,
             1,

--- a/__tests__/Settler.test.js
+++ b/__tests__/Settler.test.js
@@ -25,7 +25,8 @@ describe('Settler', () => {
             resourcePiles: [],
             addResourcePile: jest.fn(function(pile) { this.resourcePiles.push(pile); }),
             tileSize: 1,
-            buildings: []
+            buildings: [],
+            isTileBlocked: jest.fn(() => false)
         };
         mockRoomManager = {
             rooms: [],

--- a/src/js/animalPen.js
+++ b/src/js/animalPen.js
@@ -1,9 +1,9 @@
 import Building from './building.js';
-import { RESOURCE_TYPES } from './constants.js';
+import { RESOURCE_TYPES, BUILDING_TYPES } from './constants.js';
 
 export default class AnimalPen extends Building {
     constructor(x, y) {
-        super('animal_pen', x, y, 2, 2, RESOURCE_TYPES.WOOD, 100); // Animal pens are 2x2, built with wood, 100 health
+        super(BUILDING_TYPES.ANIMAL_PEN, x, y, 2, 2, RESOURCE_TYPES.WOOD, 100); // Animal pens are 2x2, built with wood, 100 health
         this.animals = []; // Array to hold animals
         this.maxAnimals = 5; // Max animals the pen can hold
     }

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -3,7 +3,13 @@ import { RESOURCE_TYPES } from './constants.js';
 
 export default class Building {
     constructor(type, x, y, width, height, material, buildProgress, resourcesRequired = 1) {
-        this.type = type; // e.g., "wall", "floor", "house"
+        if (typeof type === 'object') {
+            this.type = type.id;
+            this.blocking = !!type.blocking;
+        } else {
+            this.type = type; // fallback for string usage
+            this.blocking = false;
+        }
         this.x = x;
         this.y = y;
         this.width = width;
@@ -105,7 +111,8 @@ export default class Building {
             resourcesDelivered: this.resourcesDelivered,
             maxHealth: this.maxHealth,
             health: this.health,
-            inventory: this.inventory
+            inventory: this.inventory,
+            blocking: this.blocking
         };
     }
 
@@ -122,5 +129,6 @@ export default class Building {
         this.maxHealth = data.maxHealth;
         this.health = data.health;
         this.inventory = data.inventory || {};
+        this.blocking = data.blocking || false;
     }
 }

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -73,3 +73,18 @@ export const GATHER_TASK_TYPES = new Set([
 // Movement speeds
 export const SETTLER_RUN_SPEED = 0.5; // tiles per second
 export const ENEMY_RUN_SPEED = 0.3; // tiles per second
+
+// Building type definitions. Each has an id string used throughout the game
+// and a `blocking` property determining if it prevents movement through its
+// tile. Only walls block movement by default.
+export const BUILDING_TYPES = {
+  WALL: { id: 'wall', blocking: true },
+  FLOOR: { id: 'floor', blocking: false },
+  CRAFTING_STATION: { id: 'crafting_station', blocking: false },
+  FARM_PLOT: { id: 'farm_plot', blocking: false },
+  ANIMAL_PEN: { id: 'animal_pen', blocking: false },
+  BED: { id: 'bed', blocking: false },
+  TABLE: { id: 'table', blocking: false },
+  BARRICADE: { id: 'barricade', blocking: false }
+};
+

--- a/src/js/craftingStation.js
+++ b/src/js/craftingStation.js
@@ -1,10 +1,10 @@
 import Building from './building.js';
 import Recipe from './recipe.js';
-import { RESOURCE_TYPES } from './constants.js';
+import { RESOURCE_TYPES, BUILDING_TYPES } from './constants.js';
 
 export default class CraftingStation extends Building {
     constructor(x, y, spriteManager = null) {
-        super("crafting_station", x, y, 1, 1, RESOURCE_TYPES.WOOD, 0);
+        super(BUILDING_TYPES.CRAFTING_STATION, x, y, 1, 1, RESOURCE_TYPES.WOOD, 0);
         this.drawBase = false;
         this.spriteManager = spriteManager;
         this.stationSprite = spriteManager ? spriteManager.getSprite('crafting_station') : null;

--- a/src/js/enemy.js
+++ b/src/js/enemy.js
@@ -40,15 +40,29 @@ export default class Enemy {
             } else {
                 // Move towards the target settler
                 const speed = ENEMY_RUN_SPEED; // tiles per second
+                const step = speed * (deltaTime / 1000);
+
                 if (this.x < this.targetSettler.x) {
-                    this.x += speed * (deltaTime / 1000);
+                    const nextX = this.x + step;
+                    if (!this.targetSettler.map.isTileBlocked(Math.floor(nextX), Math.floor(this.y))) {
+                        this.x = nextX;
+                    }
                 } else if (this.x > this.targetSettler.x) {
-                    this.x -= speed * (deltaTime / 1000);
+                    const nextX = this.x - step;
+                    if (!this.targetSettler.map.isTileBlocked(Math.floor(nextX), Math.floor(this.y))) {
+                        this.x = nextX;
+                    }
                 }
                 if (this.y < this.targetSettler.y) {
-                    this.y += speed * (deltaTime / 1000);
+                    const nextY = this.y + step;
+                    if (!this.targetSettler.map.isTileBlocked(Math.floor(this.x), Math.floor(nextY))) {
+                        this.y = nextY;
+                    }
                 } else if (this.y > this.targetSettler.y) {
-                    this.y -= speed * (deltaTime / 1000);
+                    const nextY = this.y - step;
+                    if (!this.targetSettler.map.isTileBlocked(Math.floor(this.x), Math.floor(nextY))) {
+                        this.y = nextY;
+                    }
                 }
 
                 // Check if within attack range (simple distance check)

--- a/src/js/farmPlot.js
+++ b/src/js/farmPlot.js
@@ -1,11 +1,11 @@
 import Building from './building.js';
 import SpriteManager from './spriteManager.js';
-import { RESOURCE_TYPES } from './constants.js';
+import { RESOURCE_TYPES, BUILDING_TYPES } from './constants.js';
 
 export default class FarmPlot extends Building {
     constructor(x, y, spriteManager) {
         // Farm plots require no construction materials
-        super('farm_plot', x, y, 1, 1, null, 0, 0);
+        super(BUILDING_TYPES.FARM_PLOT, x, y, 1, 1, null, 0, 0);
         this.drawBase = false;
         this.crop = null; // What is planted (e.g., 'wheat')
         this.growthStage = 0; // 0: empty, 1: planted, 2: growing, 3: mature

--- a/src/js/furniture.js
+++ b/src/js/furniture.js
@@ -1,8 +1,10 @@
 import Building from './building.js';
+import { BUILDING_TYPES } from './constants.js';
 
 export default class Furniture extends Building {
     constructor(type, x, y, width, height, material, health, spriteManager = null) {
-        super(type, x, y, width, height, material, health);
+        const typeConst = typeof type === 'string' ? { id: type, blocking: false } : type;
+        super(typeConst, x, y, width, height, material, health);
         this.drawBase = false;
         this.spriteManager = spriteManager;
         this.sprite = spriteManager ? spriteManager.getSprite(type) : null;

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -21,7 +21,7 @@ import Enemy from './enemy.js';
 import EventManager from './eventManager.js';
 import NotificationManager from './notificationManager.js';
 import SoundManager from './soundManager.js';
-import { ACTION_BEEP_URL, GATHER_TASK_TYPES, TASK_TYPES, RESOURCE_TYPES } from './constants.js';
+import { ACTION_BEEP_URL, GATHER_TASK_TYPES, TASK_TYPES, RESOURCE_TYPES, BUILDING_TYPES } from './constants.js';
 
 
 export default class Game {
@@ -647,22 +647,22 @@ export default class Game {
         if (this.buildMode && this.selectedBuilding) {
             // Place the selected building
             let newBuilding;
-            if (this.selectedBuilding === 'crafting_station') {
+            if (this.selectedBuilding === BUILDING_TYPES.CRAFTING_STATION.id) {
                 newBuilding = new CraftingStation(tileX, tileY, this.spriteManager);
-            } else if (this.selectedBuilding === 'farm_plot') {
+            } else if (this.selectedBuilding === BUILDING_TYPES.FARM_PLOT.id) {
                 newBuilding = new FarmPlot(tileX, tileY, this.spriteManager);
-            } else if (this.selectedBuilding === 'animal_pen') {
+            } else if (this.selectedBuilding === BUILDING_TYPES.ANIMAL_PEN.id) {
                 newBuilding = new AnimalPen(tileX, tileY);
-            } else if (this.selectedBuilding === 'bed') {
-                newBuilding = new Furniture('bed', tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 50, this.spriteManager);
-            } else if (this.selectedBuilding === 'table') {
-                newBuilding = new Furniture('table', tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 75, this.spriteManager);
-            } else if (this.selectedBuilding === 'barricade') {
-                newBuilding = new Building('barricade', tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 0); // Barricade is a simple building
-            } else if (this.selectedBuilding === 'wall') {
-                newBuilding = new Building('wall', tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 0, 1); // Walls require 1 wood
+            } else if (this.selectedBuilding === BUILDING_TYPES.BED.id) {
+                newBuilding = new Furniture(BUILDING_TYPES.BED, tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 50, this.spriteManager);
+            } else if (this.selectedBuilding === BUILDING_TYPES.TABLE.id) {
+                newBuilding = new Furniture(BUILDING_TYPES.TABLE, tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 75, this.spriteManager);
+            } else if (this.selectedBuilding === BUILDING_TYPES.BARRICADE.id) {
+                newBuilding = new Building(BUILDING_TYPES.BARRICADE, tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 0);
+            } else if (this.selectedBuilding === BUILDING_TYPES.WALL.id) {
+                newBuilding = new Building(BUILDING_TYPES.WALL, tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 0, 1);
             } else {
-                newBuilding = new Building(this.selectedBuilding, tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 0); // Start with 0 health
+                newBuilding = new Building({ id: this.selectedBuilding, blocking: false }, tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 0);
             }
             this.map.addBuilding(newBuilding);
             // Hauling should happen before building starts if resources are needed

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -123,6 +123,12 @@ export default class Map {
         return this.buildings.find(building => building.x === x && building.y === y);
     }
 
+    isTileBlocked(x, y) {
+        if (this.getTile(x, y) === 8) return true;
+        const building = this.getBuildingAt(x, y);
+        return !!(building && building.blocking);
+    }
+
     removeBuilding(buildingToRemove) {
         this.buildings = this.buildings.filter(building => building !== buildingToRemove);
     }
@@ -150,8 +156,7 @@ export default class Map {
                 nx < this.width &&
                 ny >= 0 &&
                 ny < this.height &&
-                this.getTile(nx, ny) !== 8 &&
-                !this.getBuildingAt(nx, ny)
+                !this.isTileBlocked(nx, ny)
             ) {
                 if (fromX !== null && fromY !== null) {
                     const dist = (fromX - nx) ** 2 + (fromY - ny) ** 2;

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -270,15 +270,42 @@ export default class Settler {
         if (this.currentTask) {
             // Move towards the target
             const speed = SETTLER_RUN_SPEED; // tiles per second
+            const step = speed * (deltaTime / 1000);
+
             if (this.x < this.currentTask.targetX) {
-                this.x += speed * (deltaTime / 1000);
+                const nextX = this.x + step;
+                if (!this.map.isTileBlocked(Math.floor(nextX), Math.floor(this.y))) {
+                    this.x = nextX;
+                } else if (this.y !== this.currentTask.targetY) {
+                    const dirY = this.y < this.currentTask.targetY ? 1 : -1;
+                    const nextY = this.y + dirY * step;
+                    if (!this.map.isTileBlocked(Math.floor(this.x), Math.floor(nextY))) {
+                        this.y = nextY;
+                    }
+                }
             } else if (this.x > this.currentTask.targetX) {
-                this.x -= speed * (deltaTime / 1000);
+                const nextX = this.x - step;
+                if (!this.map.isTileBlocked(Math.floor(nextX), Math.floor(this.y))) {
+                    this.x = nextX;
+                } else if (this.y !== this.currentTask.targetY) {
+                    const dirY = this.y < this.currentTask.targetY ? 1 : -1;
+                    const nextY = this.y + dirY * step;
+                    if (!this.map.isTileBlocked(Math.floor(this.x), Math.floor(nextY))) {
+                        this.y = nextY;
+                    }
+                }
             }
+
             if (this.y < this.currentTask.targetY) {
-                this.y += speed * (deltaTime / 1000);
+                const nextY = this.y + step;
+                if (!this.map.isTileBlocked(Math.floor(this.x), Math.floor(nextY))) {
+                    this.y = nextY;
+                }
             } else if (this.y > this.currentTask.targetY) {
-                this.y -= speed * (deltaTime / 1000);
+                const nextY = this.y - step;
+                if (!this.map.isTileBlocked(Math.floor(this.x), Math.floor(nextY))) {
+                    this.y = nextY;
+                }
             }
 
             // Check if arrived at target

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -1,5 +1,5 @@
 
-import { TASK_TYPES, RESOURCE_TYPES } from './constants.js';
+import { TASK_TYPES, RESOURCE_TYPES, BUILDING_TYPES } from './constants.js';
 
 export default class UI {
     constructor(ctx) {
@@ -387,16 +387,16 @@ export default class UI {
 
         switch (categoryId) {
             case 'buildings':
-                createButton('Build Wall', 'wall', false, 'Builds a defensive wall.');
-                createButton('Build Floor', 'floor', false, 'Lays down a floor tile.');
-                createButton('Build Crafting Station', 'crafting_station', false, 'Allows settlers to craft items.');
-                createButton('Build Farm Plot', 'farm_plot', false, 'Used for growing crops.');
-                createButton('Build Animal Pen', 'animal_pen', false, 'Houses livestock.');
-                createButton('Build Barricade', 'barricade', false, 'A simple defensive barrier.');
+                createButton('Build Wall', BUILDING_TYPES.WALL.id, false, 'Builds a defensive wall.');
+                createButton('Build Floor', BUILDING_TYPES.FLOOR.id, false, 'Lays down a floor tile.');
+                createButton('Build Crafting Station', BUILDING_TYPES.CRAFTING_STATION.id, false, 'Allows settlers to craft items.');
+                createButton('Build Farm Plot', BUILDING_TYPES.FARM_PLOT.id, false, 'Used for growing crops.');
+                createButton('Build Animal Pen', BUILDING_TYPES.ANIMAL_PEN.id, false, 'Houses livestock.');
+                createButton('Build Barricade', BUILDING_TYPES.BARRICADE.id, false, 'A simple defensive barrier.');
                 break;
             case 'furniture':
-                createButton('Place Bed', 'bed', false, 'Provides a place for settlers to sleep.');
-                createButton('Place Table', 'table', false, 'A surface for various activities.');
+                createButton('Place Bed', BUILDING_TYPES.BED.id, false, 'Provides a place for settlers to sleep.');
+                createButton('Place Table', BUILDING_TYPES.TABLE.id, false, 'A surface for various activities.');
                 break;
             case 'zones':
                 createButton('Designate Bedroom', 'bedroom', true, 'Designates an area as a bedroom.');


### PR DESCRIPTION
## Summary
- centralize building type definitions in `constants.js`
- mark wall as blocking and carry blocking info on building instances
- add tile blocking checks in `Map`, `Settler`, and `Enemy`
- update UI, game logic, and building classes to use building constants
- adjust tests for new constants and mock methods

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886622b48988323943bf356ad93602d