### PR TITLE
Add sprite loading progress bar

### DIFF
--- a/__tests__/UI.test.js
+++ b/__tests__/UI.test.js
@@ -64,4 +64,14 @@ describe('UI tooltips', () => {
         ui.hideCraftingStationMenu();
         expect(ui.craftingStationMenu.style.display).toBe('none');
     });
+
+    test('loading screen shows and updates', () => {
+        const ui = new UI({});
+        ui.showLoadingScreen();
+        ui.updateLoadingProgress(0.5);
+        expect(ui.loadingScreen.style.display).toBe('flex');
+        expect(ui.loadingBar.style.width).toBe('50%');
+        ui.hideLoadingScreen();
+        expect(ui.loadingScreen.style.display).toBe('none');
+    });
 });

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -114,3 +114,31 @@ canvas {
 .priority-label {
     margin-right: 10px;
 }
+
+/* Loading screen styles */
+#loading-screen {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.8);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 2000;
+}
+
+#loading-bar-container {
+    width: 80%;
+    height: 20px;
+    background-color: #444;
+    border-radius: 10px;
+    overflow: hidden;
+}
+
+#loading-bar {
+    height: 100%;
+    width: 0%;
+    background-color: #4caf50;
+}

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -73,43 +73,51 @@ export default class Game {
 
     async start() {
         try {
-            
-            await this.spriteManager.loadImage('settler', 'src/assets/settler.png');
-            await this.spriteManager.loadImage('tree', 'src/assets/tree.png');
-            await this.spriteManager.loadImage('grass', 'src/assets/grass.png');
-            await this.spriteManager.loadImage('water', 'src/assets/water.png');
-            await this.spriteManager.loadImage('berry_bush', 'src/assets/berry_bush.png');
-            await this.spriteManager.loadImage('goblin', 'src/assets/goblin.png');
-            await this.spriteManager.loadImage(RESOURCE_TYPES.STONE, 'src/assets/stone.png');
-            await this.spriteManager.loadImage(RESOURCE_TYPES.IRON_ORE, 'src/assets/iron_ore.png');
-            await this.spriteManager.loadImage('deer', 'src/assets/deer.png');
-            await this.spriteManager.loadImage(RESOURCE_TYPES.DIRT, 'src/assets/dirt.png');
-            await this.spriteManager.loadImage('wild_boar', 'src/assets/wild_boar.png');
-            await this.spriteManager.loadImage('mushroom', 'src/assets/mushroom.png');
-            await this.spriteManager.loadImage('mushrooms', 'src/assets/mushrooms.png');
-            await this.spriteManager.loadImage(RESOURCE_TYPES.WOOD, 'src/assets/wood.png');
-            await this.spriteManager.loadImage('stone_pile', 'src/assets/stone_pile.png');
-            await this.spriteManager.loadImage(RESOURCE_TYPES.BERRIES, 'src/assets/berries.png');
-            await this.spriteManager.loadImage(RESOURCE_TYPES.MEAT, 'src/assets/meat.png');
+            this.ui.showLoadingScreen();
+            const sprites = [
+                ['settler', 'src/assets/settler.png'],
+                ['tree', 'src/assets/tree.png'],
+                ['grass', 'src/assets/grass.png'],
+                ['water', 'src/assets/water.png'],
+                ['berry_bush', 'src/assets/berry_bush.png'],
+                ['goblin', 'src/assets/goblin.png'],
+                [RESOURCE_TYPES.STONE, 'src/assets/stone.png'],
+                [RESOURCE_TYPES.IRON_ORE, 'src/assets/iron_ore.png'],
+                ['deer', 'src/assets/deer.png'],
+                [RESOURCE_TYPES.DIRT, 'src/assets/dirt.png'],
+                ['wild_boar', 'src/assets/wild_boar.png'],
+                ['mushroom', 'src/assets/mushroom.png'],
+                ['mushrooms', 'src/assets/mushrooms.png'],
+                [RESOURCE_TYPES.WOOD, 'src/assets/wood.png'],
+                ['stone_pile', 'src/assets/stone_pile.png'],
+                [RESOURCE_TYPES.BERRIES, 'src/assets/berries.png'],
+                [RESOURCE_TYPES.MEAT, 'src/assets/meat.png'],
+                ['dirt_pile', 'src/assets/dirt_pile.png'],
+                ['farm_plot', 'src/assets/farmPlot.png'],
+                [RESOURCE_TYPES.BANDAGE, 'src/assets/bandage.png'],
+                ['crafting_station', 'src/assets/crafting_station.png'],
+                ['table', 'src/assets/table.png'],
+                ['bed', 'src/assets/bed.png'],
+                ['wheat_1', 'src/assets/wheat_1.png'],
+                ['wheat_2', 'src/assets/wheat_2.png'],
+                ['wheat_3', 'src/assets/wheat_3.png'],
+                ['wheat_pile', 'src/assets/wheat_pile.png'],
+                ['cotton_1', 'src/assets/cotton_1.png'],
+                ['cotton_2', 'src/assets/cotton_2.png'],
+                ['cotton_3', 'src/assets/cotton_3.png'],
+                ['cotton_pile', 'src/assets/cotton_pile.png'],
+                ['iron_ore_pile', 'src/assets/iron_ore_pile.png']
+            ];
+            for (let i = 0; i < sprites.length; i++) {
+                const [name, src] = sprites[i];
+                await this.spriteManager.loadImage(name, src);
+                this.ui.updateLoadingProgress((i + 1) / sprites.length);
+            }
             await this.soundManager.loadSound('action', ACTION_BEEP_URL);
-            
-            await this.spriteManager.loadImage('dirt_pile', 'src/assets/dirt_pile.png');
-            await this.spriteManager.loadImage('farm_plot', 'src/assets/farmPlot.png');
-            await this.spriteManager.loadImage(RESOURCE_TYPES.BANDAGE, 'src/assets/bandage.png');
-            await this.spriteManager.loadImage('crafting_station', 'src/assets/crafting_station.png');
-            await this.spriteManager.loadImage('table', 'src/assets/table.png');
-            await this.spriteManager.loadImage('bed', 'src/assets/bed.png');
-            await this.spriteManager.loadImage('wheat_1', 'src/assets/wheat_1.png');
-            await this.spriteManager.loadImage('wheat_2', 'src/assets/wheat_2.png');
-            await this.spriteManager.loadImage('wheat_3', 'src/assets/wheat_3.png');
-            await this.spriteManager.loadImage('wheat_pile', 'src/assets/wheat_pile.png');
-            await this.spriteManager.loadImage('cotton_1', 'src/assets/cotton_1.png');
-            await this.spriteManager.loadImage('cotton_2', 'src/assets/cotton_2.png');
-            await this.spriteManager.loadImage('cotton_3', 'src/assets/cotton_3.png');
-            await this.spriteManager.loadImage('cotton_pile', 'src/assets/cotton_pile.png');
-            await this.spriteManager.loadImage('iron_ore_pile', 'src/assets/iron_ore_pile.png');
         } catch (error) {
             console.error("Failed to load sprite:", error);
+        } finally {
+            this.ui.hideLoadingScreen();
         }
 
         // Create a new settler

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -8,6 +8,18 @@ export default class UI {
         this.uiContainer.id = 'ui-container';
         document.body.appendChild(this.uiContainer);
 
+        // Loading screen elements
+        this.loadingScreen = document.createElement('div');
+        this.loadingScreen.id = 'loading-screen';
+        const barContainer = document.createElement('div');
+        barContainer.id = 'loading-bar-container';
+        this.loadingBar = document.createElement('div');
+        this.loadingBar.id = 'loading-bar';
+        barContainer.appendChild(this.loadingBar);
+        this.loadingScreen.appendChild(barContainer);
+        this.loadingScreen.style.display = 'none';
+        document.body.appendChild(this.loadingScreen);
+
         this.timeElement = document.createElement('span');
         this.timeElement.id = 'time-display';
         this.uiContainer.appendChild(this.timeElement);
@@ -535,5 +547,18 @@ export default class UI {
     hideCraftingStationMenu() {
         this.craftingStationMenu.style.display = 'none';
         this.selectedCraftingStation = null;
+    }
+
+    showLoadingScreen() {
+        this.loadingScreen.style.display = 'flex';
+        this.updateLoadingProgress(0);
+    }
+
+    updateLoadingProgress(progress) {
+        this.loadingBar.style.width = `${Math.floor(progress * 100)}%`;
+    }
+
+    hideLoadingScreen() {
+        this.loadingScreen.style.display = 'none';
     }
 }


### PR DESCRIPTION
## Summary
- add loading screen CSS and DOM elements
- implement UI helpers to show loading progress
- load sprites via array with progress updates
- test loading screen behaviour

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688662f96e2c832390b45d3f55a4d032