### PR TITLE
Centralize building type constants

### DIFF
--- a/__tests__/Building.test.js
+++ b/__tests__/Building.test.js
@@ -1,10 +1,11 @@
 import Building from '../src/js/building.js';
+import { BUILDING_TYPES } from '../src/js/constants.js';
 
 import Map from '../src/js/map.js';
 
 describe('Building', () => {
     test('takeDamage reduces health and does not go below zero', () => {
-        const building = new Building('barricade', 0, 0, 1, 1, 'wood', 100);
+        const building = new Building(BUILDING_TYPES.BARRICADE, 0, 0, 1, 1, 'wood', 100);
         building.takeDamage(30);
         expect(building.health).toBe(70);
         building.takeDamage(100);
@@ -13,7 +14,7 @@ describe('Building', () => {
 
     test('spillInventory drops resources as piles', () => {
         const map = new Map(10, 10, 32, { getSprite: jest.fn() });
-        const building = new Building('wall', 1, 1, 1, 1, 'wood', 0, 5);
+        const building = new Building(BUILDING_TYPES.WALL, 1, 1, 1, 1, 'wood', 0, 5);
         building.addToInventory('wood', 5);
         map.addBuilding(building);
 

--- a/__tests__/CraftingStation.test.js
+++ b/__tests__/CraftingStation.test.js
@@ -1,6 +1,7 @@
 import CraftingStation from '../src/js/craftingStation.js';
 import Recipe from '../src/js/recipe.js';
 import SpriteManager from '../src/js/spriteManager.js';
+import { BUILDING_TYPES } from '../src/js/constants.js';
 
 
 jest.mock('../src/js/recipe.js');
@@ -13,7 +14,7 @@ describe('CraftingStation', () => {
     });
 
     test('should initialize with correct properties', () => {
-        expect(craftingStation.type).toBe('crafting_station');
+        expect(craftingStation.type).toBe(BUILDING_TYPES.CRAFTING_STATION);
         expect(craftingStation.x).toBe(0);
         expect(craftingStation.y).toBe(0);
         expect(craftingStation.recipes).toEqual([expect.any(Recipe)]);

--- a/__tests__/Game.test.js
+++ b/__tests__/Game.test.js
@@ -1,4 +1,5 @@
 import Game from '../src/js/game.js';
+import { BUILDING_TYPES } from '../src/js/constants.js';
 import Map from '../src/js/map.js';
 import UI from '../src/js/ui.js';
 import ResourceManager from '../src/js/resourceManager.js';
@@ -101,17 +102,17 @@ describe('Game', () => {
     });
 
     test('toggleBuildMode should set buildMode and selectedBuilding', () => {
-        game.toggleBuildMode('wall');
+        game.toggleBuildMode(BUILDING_TYPES.WALL);
         expect(game.buildMode).toBe(true);
-        expect(game.selectedBuilding).toBe('wall');
+        expect(game.selectedBuilding).toBe(BUILDING_TYPES.WALL);
 
-        game.toggleBuildMode('wall'); // Toggle off
+        game.toggleBuildMode(BUILDING_TYPES.WALL); // Toggle off
         expect(game.buildMode).toBe(false);
         expect(game.selectedBuilding).toBe(null);
 
-        game.toggleBuildMode('floor'); // Toggle on with new type
+        game.toggleBuildMode(BUILDING_TYPES.FLOOR); // Toggle on with new type
         expect(game.buildMode).toBe(true);
-        expect(game.selectedBuilding).toBe('floor');
+        expect(game.selectedBuilding).toBe(BUILDING_TYPES.FLOOR);
     });
 
     test('handleClick should place a building when in build mode', () => {
@@ -119,14 +120,14 @@ describe('Game', () => {
         const expectedTileX = Math.floor(((100 - mockCtx.canvas.width / 2) / game.camera.zoom + game.camera.x) / game.map.tileSize);
         const expectedTileY = Math.floor(((100 - mockCtx.canvas.height / 2) / game.camera.zoom + game.camera.y) / game.map.tileSize);
         game.map.findAdjacentFreeTile = jest.fn().mockReturnValue({ x: expectedTileX + 1, y: expectedTileY });
-        game.toggleBuildMode('wall');
+        game.toggleBuildMode(BUILDING_TYPES.WALL);
         game.handleClick({ clientX: 100, clientY: 100, target: { closest: () => null } });
 
         expect(game.map.addBuilding).toHaveBeenCalledTimes(1);
         expect(game.map.addBuilding).toHaveBeenCalledWith(expect.any(Object));
         // Verify the Building constructor was called with correct arguments
         expect(Building).toHaveBeenCalledWith(
-            'wall',
+            BUILDING_TYPES.WALL,
             expectedTileX,
             expectedTileY,
             1,
@@ -156,13 +157,13 @@ describe('Game', () => {
         const expectedTileX = Math.floor(((100 - mockCtx.canvas.width / 2) / game.camera.zoom + game.camera.x) / game.map.tileSize);
         const expectedTileY = Math.floor(((100 - mockCtx.canvas.height / 2) / game.camera.zoom + game.camera.y) / game.map.tileSize);
         game.map.findAdjacentFreeTile = jest.fn().mockReturnValue({ x: expectedTileX + 1, y: expectedTileY });
-        game.toggleBuildMode('farm_plot');
+        game.toggleBuildMode(BUILDING_TYPES.FARM_PLOT);
         game.handleClick({ clientX: 100, clientY: 100, target: { closest: () => null } });
 
         expect(game.map.addBuilding).toHaveBeenCalledTimes(1);
         expect(game.map.addBuilding).toHaveBeenCalledWith(expect.any(Object));
         expect(Building).toHaveBeenCalledWith(
-            'farm_plot',
+            BUILDING_TYPES.FARM_PLOT,
             expectedTileX,
             expectedTileY,
             1,
@@ -188,7 +189,7 @@ describe('Game', () => {
     test('handleClick on farm plot shows menu', () => {
         const tileX = Math.floor(((100 - mockCtx.canvas.width / 2) / game.camera.zoom + game.camera.x) / game.map.tileSize);
         const tileY = Math.floor(((100 - mockCtx.canvas.height / 2) / game.camera.zoom + game.camera.y) / game.map.tileSize);
-        const farmPlot = { type: 'farm_plot', x: tileX, y: tileY, growthStage: 0 };
+        const farmPlot = { type: BUILDING_TYPES.FARM_PLOT, x: tileX, y: tileY, growthStage: 0 };
         game.map.getBuildingAt.mockReturnValue(farmPlot);
         game.handleClick({ clientX: 100, clientY: 100, target: { closest: () => null } });
         expect(game.ui.showFarmPlotMenu).toHaveBeenCalledWith(farmPlot, 100, 100);
@@ -264,7 +265,7 @@ describe('Game', () => {
     });
 
     test('auto sow and harvest create tasks', () => {
-        const farmPlot = { type: 'farm_plot', x: 1, y: 2, crop: null, growthStage: 0, autoSow: true, autoHarvest: true, desiredCrop: 'wheat' };
+        const farmPlot = { type: BUILDING_TYPES.FARM_PLOT, x: 1, y: 2, crop: null, growthStage: 0, autoSow: true, autoHarvest: true, desiredCrop: 'wheat' };
         game.map.getAllBuildings.mockReturnValue([farmPlot]);
         game.taskManager.tasks = [];
         game.update(16);

--- a/__tests__/Settler.test.js
+++ b/__tests__/Settler.test.js
@@ -1,6 +1,6 @@
 import Settler from '../src/js/settler.js';
 import Task from '../src/js/task.js';
-import { TASK_TYPES, HEALTH_REGEN_RATE } from '../src/js/constants.js';
+import { TASK_TYPES, HEALTH_REGEN_RATE, BUILDING_TYPES } from '../src/js/constants.js';
 import ResourcePile from '../src/js/resourcePile.js';
 
 jest.mock('../src/js/resourceManager.js');
@@ -520,7 +520,7 @@ describe('Settler', () => {
     });
 
     test('seeking_sleep finds a bed and assigns sleep task', () => {
-        const bed = { type: 'bed', x: 1, y: 1, occupant: null };
+        const bed = { type: BUILDING_TYPES.BED, x: 1, y: 1, occupant: null };
         mockMap.buildings = [bed];
         settler.sleep = 10;
 

--- a/src/js/animalPen.js
+++ b/src/js/animalPen.js
@@ -1,9 +1,9 @@
 import Building from './building.js';
-import { RESOURCE_TYPES } from './constants.js';
+import { RESOURCE_TYPES, BUILDING_TYPES } from './constants.js';
 
 export default class AnimalPen extends Building {
     constructor(x, y) {
-        super('animal_pen', x, y, 2, 2, RESOURCE_TYPES.WOOD, 100); // Animal pens are 2x2, built with wood, 100 health
+        super(BUILDING_TYPES.ANIMAL_PEN, x, y, 2, 2, RESOURCE_TYPES.WOOD, 100); // Animal pens are 2x2, built with wood, 100 health
         this.animals = []; // Array to hold animals
         this.maxAnimals = 5; // Max animals the pen can hold
     }

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -5,6 +5,18 @@ export const ACTION_BEEP_URL = "data:audio/wav;base64,UklGRrQBAABXQVZFZm10IBAAAA
 export const SLEEP_GAIN_RATE = 0.01; // base sleep recovery per second
 export const HEALTH_REGEN_RATE = 0.005; // base health regen per second at full hunger
 
+// Building types used across the game
+export const BUILDING_TYPES = {
+  WALL: 'wall',
+  FLOOR: 'floor',
+  CRAFTING_STATION: 'crafting_station',
+  FARM_PLOT: 'farm_plot',
+  ANIMAL_PEN: 'animal_pen',
+  BARRICADE: 'barricade',
+  BED: 'bed',
+  TABLE: 'table'
+};
+
 // Resource types used throughout the game
 export const RESOURCE_TYPES = {
   WOOD: 'wood',

--- a/src/js/craftingStation.js
+++ b/src/js/craftingStation.js
@@ -1,13 +1,13 @@
 import Building from './building.js';
 import Recipe from './recipe.js';
-import { RESOURCE_TYPES } from './constants.js';
+import { RESOURCE_TYPES, BUILDING_TYPES } from './constants.js';
 
 export default class CraftingStation extends Building {
     constructor(x, y, spriteManager = null) {
-        super("crafting_station", x, y, 1, 1, RESOURCE_TYPES.WOOD, 0);
+        super(BUILDING_TYPES.CRAFTING_STATION, x, y, 1, 1, RESOURCE_TYPES.WOOD, 0);
         this.drawBase = false;
         this.spriteManager = spriteManager;
-        this.stationSprite = spriteManager ? spriteManager.getSprite('crafting_station') : null;
+        this.stationSprite = spriteManager ? spriteManager.getSprite(BUILDING_TYPES.CRAFTING_STATION) : null;
         this.recipes = []; // List of recipes this station can craft
         this.autoCraft = false;
         this.desiredRecipe = null;

--- a/src/js/eventManager.js
+++ b/src/js/eventManager.js
@@ -1,6 +1,6 @@
 
 import ResourcePile from './resourcePile.js';
-import { RESOURCE_TYPES } from './constants.js';
+import { RESOURCE_TYPES, BUILDING_TYPES } from './constants.js';
 export default class EventManager {
     constructor(game, EnemyClass) {
         this.EnemyClass = EnemyClass;
@@ -61,11 +61,11 @@ export default class EventManager {
             {
                 name: "Good Harvest",
                 description: "Your crops yielded an abundant harvest!",
-                condition: () => this.game.map.buildings.some(b => b.type === 'farm_plot' && b.growthStage === 3), // Only if there are mature farm plots
+                condition: () => this.game.map.buildings.some(b => b.type === BUILDING_TYPES.FARM_PLOT && b.growthStage === 3), // Only if there are mature farm plots
                 action: () => {
                     console.log("Event: Good Harvest!");
                     this.game.notificationManager.addNotification("Your crops yielded an abundant harvest!", 'success');
-                    const farmPlots = this.game.map.buildings.filter(b => b.type === 'farm_plot' && b.growthStage === 3);
+                    const farmPlots = this.game.map.buildings.filter(b => b.type === BUILDING_TYPES.FARM_PLOT && b.growthStage === 3);
                     if (farmPlots.length > 0) {
                         farmPlots.forEach(plot => {
                             const harvestedCrop = plot.harvest();

--- a/src/js/farmPlot.js
+++ b/src/js/farmPlot.js
@@ -1,17 +1,17 @@
 import Building from './building.js';
 import SpriteManager from './spriteManager.js';
-import { RESOURCE_TYPES } from './constants.js';
+import { RESOURCE_TYPES, BUILDING_TYPES } from './constants.js';
 
 export default class FarmPlot extends Building {
     constructor(x, y, spriteManager) {
         // Farm plots require no construction materials
-        super('farm_plot', x, y, 1, 1, null, 0, 0);
+        super(BUILDING_TYPES.FARM_PLOT, x, y, 1, 1, null, 0, 0);
         this.drawBase = false;
         this.crop = null; // What is planted (e.g., 'wheat')
         this.growthStage = 0; // 0: empty, 1: planted, 2: growing, 3: mature
         this.growthRate = 0.01; // How fast it grows per game tick
         this.spriteManager = spriteManager;
-        this.farmPlotSprite = spriteManager.getSprite('farm_plot');
+        this.farmPlotSprite = spriteManager.getSprite(BUILDING_TYPES.FARM_PLOT);
         this.autoSow = false;
         this.autoHarvest = false;
         this.desiredCrop = RESOURCE_TYPES.WHEAT;

--- a/src/js/furniture.js
+++ b/src/js/furniture.js
@@ -1,4 +1,5 @@
 import Building from './building.js';
+import { BUILDING_TYPES } from './constants.js';
 
 export default class Furniture extends Building {
     constructor(type, x, y, width, height, material, health, spriteManager = null) {
@@ -7,7 +8,7 @@ export default class Furniture extends Building {
         this.spriteManager = spriteManager;
         this.sprite = spriteManager ? spriteManager.getSprite(type) : null;
         this.isFurniture = true;
-        if (type === 'bed') {
+        if (type === BUILDING_TYPES.BED) {
             this.occupant = null; // Settler currently using the bed
         }
     }

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -21,7 +21,7 @@ import Enemy from './enemy.js';
 import EventManager from './eventManager.js';
 import NotificationManager from './notificationManager.js';
 import SoundManager from './soundManager.js';
-import { ACTION_BEEP_URL, GATHER_TASK_TYPES, TASK_TYPES, RESOURCE_TYPES } from './constants.js';
+import { ACTION_BEEP_URL, GATHER_TASK_TYPES, TASK_TYPES, RESOURCE_TYPES, BUILDING_TYPES } from './constants.js';
 
 
 export default class Game {
@@ -93,11 +93,11 @@ export default class Game {
                 [RESOURCE_TYPES.BERRIES, 'src/assets/berries.png'],
                 [RESOURCE_TYPES.MEAT, 'src/assets/meat.png'],
                 ['dirt_pile', 'src/assets/dirt_pile.png'],
-                ['farm_plot', 'src/assets/farmPlot.png'],
+                [BUILDING_TYPES.FARM_PLOT, 'src/assets/farmPlot.png'],
                 [RESOURCE_TYPES.BANDAGE, 'src/assets/bandage.png'],
-                ['crafting_station', 'src/assets/crafting_station.png'],
-                ['table', 'src/assets/table.png'],
-                ['bed', 'src/assets/bed.png'],
+                [BUILDING_TYPES.CRAFTING_STATION, 'src/assets/crafting_station.png'],
+                [BUILDING_TYPES.TABLE, 'src/assets/table.png'],
+                [BUILDING_TYPES.BED, 'src/assets/bed.png'],
                 ['wheat_1', 'src/assets/wheat_1.png'],
                 ['wheat_2', 'src/assets/wheat_2.png'],
                 ['wheat_3', 'src/assets/wheat_3.png'],
@@ -207,7 +207,7 @@ export default class Game {
                 building.update(deltaTime * this.gameSpeed);
             }
 
-            if (building.type === 'farm_plot') {
+            if (building.type === BUILDING_TYPES.FARM_PLOT) {
                 const farmPlot = building;
                 if (farmPlot.autoSow && farmPlot.crop === null) {
                     const hasTask = this.taskManager.tasks.some(t => t.type === TASK_TYPES.SOW_CROP && t.building === farmPlot);
@@ -224,7 +224,7 @@ export default class Game {
                     }
                 }
             }
-            if (building.type === 'crafting_station') {
+            if (building.type === BUILDING_TYPES.CRAFTING_STATION) {
                 const station = building;
                 if (station.autoCraft && station.desiredRecipe) {
                     const hasTask = this.taskManager.tasks.some(
@@ -655,20 +655,20 @@ export default class Game {
         if (this.buildMode && this.selectedBuilding) {
             // Place the selected building
             let newBuilding;
-            if (this.selectedBuilding === 'crafting_station') {
+            if (this.selectedBuilding === BUILDING_TYPES.CRAFTING_STATION) {
                 newBuilding = new CraftingStation(tileX, tileY, this.spriteManager);
-            } else if (this.selectedBuilding === 'farm_plot') {
+            } else if (this.selectedBuilding === BUILDING_TYPES.FARM_PLOT) {
                 newBuilding = new FarmPlot(tileX, tileY, this.spriteManager);
-            } else if (this.selectedBuilding === 'animal_pen') {
+            } else if (this.selectedBuilding === BUILDING_TYPES.ANIMAL_PEN) {
                 newBuilding = new AnimalPen(tileX, tileY);
-            } else if (this.selectedBuilding === 'bed') {
-                newBuilding = new Furniture('bed', tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 50, this.spriteManager);
-            } else if (this.selectedBuilding === 'table') {
-                newBuilding = new Furniture('table', tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 75, this.spriteManager);
-            } else if (this.selectedBuilding === 'barricade') {
-                newBuilding = new Building('barricade', tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 0); // Barricade is a simple building
-            } else if (this.selectedBuilding === 'wall') {
-                newBuilding = new Building('wall', tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 0, 1); // Walls require 1 wood
+            } else if (this.selectedBuilding === BUILDING_TYPES.BED) {
+                newBuilding = new Furniture(BUILDING_TYPES.BED, tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 50, this.spriteManager);
+            } else if (this.selectedBuilding === BUILDING_TYPES.TABLE) {
+                newBuilding = new Furniture(BUILDING_TYPES.TABLE, tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 75, this.spriteManager);
+            } else if (this.selectedBuilding === BUILDING_TYPES.BARRICADE) {
+                newBuilding = new Building(BUILDING_TYPES.BARRICADE, tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 0); // Barricade is a simple building
+            } else if (this.selectedBuilding === BUILDING_TYPES.WALL) {
+                newBuilding = new Building(BUILDING_TYPES.WALL, tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 0, 1); // Walls require 1 wood
             } else {
                 newBuilding = new Building(this.selectedBuilding, tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 0); // Start with 0 health
             }
@@ -719,13 +719,13 @@ export default class Game {
                 // Check if a building was clicked
                 const clickedBuilding = this.map.getBuildingAt(tileX, tileY);
                 if (clickedBuilding) {
-                    if (clickedBuilding.type === 'crafting_station') {
+                    if (clickedBuilding.type === BUILDING_TYPES.CRAFTING_STATION) {
                         const craftingStation = clickedBuilding;
                         this.ui.showCraftingStationMenu(craftingStation, event.clientX, event.clientY);
-                    } else if (clickedBuilding.type === 'farm_plot') {
+                    } else if (clickedBuilding.type === BUILDING_TYPES.FARM_PLOT) {
                         const farmPlot = clickedBuilding;
                         this.ui.showFarmPlotMenu(farmPlot, event.clientX, event.clientY);
-                    } else if (clickedBuilding.type === 'animal_pen') {
+                    } else if (clickedBuilding.type === BUILDING_TYPES.ANIMAL_PEN) {
                         const animalPen = clickedBuilding;
                         this.taskManager.addTask(new Task(TASK_TYPES.TEND_ANIMALS, tileX, tileY, null, 0, 3, animalPen));
                         console.log(`Tend animals task added at ${tileX},${tileY}`);

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -4,6 +4,7 @@ import CraftingStation from './craftingStation.js';
 import FarmPlot from './farmPlot.js';
 import AnimalPen from './animalPen.js';
 import Furniture from './furniture.js';
+import { BUILDING_TYPES } from './constants.js';
 
 export default class Map {
     constructor(width, height, tileSize, spriteManager) {
@@ -222,7 +223,7 @@ export default class Map {
         const floors = [];
         const nonFloors = [];
         for (const building of this.buildings) {
-            if (building.type === 'floor') {
+            if (building.type === BUILDING_TYPES.FLOOR) {
                 floors.push(building);
             } else {
                 nonFloors.push(building);
@@ -263,19 +264,19 @@ export default class Map {
         this.buildings = data.buildings.map(buildingData => {
             // Re-instantiate based on type if needed, otherwise use base Building
             let building;
-            if (buildingData.type === 'crafting_station') {
+            if (buildingData.type === BUILDING_TYPES.CRAFTING_STATION) {
                 building = new CraftingStation(buildingData.x, buildingData.y, this.spriteManager);
-            } else if (buildingData.type === 'farm_plot') {
+            } else if (buildingData.type === BUILDING_TYPES.FARM_PLOT) {
                 building = new FarmPlot(buildingData.x, buildingData.y, this.spriteManager);
-            } else if (buildingData.type === 'animal_pen') {
+            } else if (buildingData.type === BUILDING_TYPES.ANIMAL_PEN) {
                 building = new AnimalPen(buildingData.x, buildingData.y);
-            } else if (buildingData.type === 'bed' || buildingData.type === 'table') {
+            } else if (buildingData.type === BUILDING_TYPES.BED || buildingData.type === BUILDING_TYPES.TABLE) {
                 building = new Furniture(buildingData.type, buildingData.x, buildingData.y, 1, 1, buildingData.material, buildingData.health, this.spriteManager);
             } else {
                 building = new Building(buildingData.type, buildingData.x, buildingData.y, buildingData.width, buildingData.height, buildingData.material, buildingData.health);
             }
             building.deserialize(buildingData);
-            if (building.type === 'bed' || building.type === 'table') {
+            if (building.type === BUILDING_TYPES.BED || building.type === BUILDING_TYPES.TABLE) {
                 building.width = 1;
                 building.height = 1;
             }

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -1,7 +1,7 @@
 
 import Task from './task.js';
 import ResourcePile from './resourcePile.js';
-import { SLEEP_GAIN_RATE, SETTLER_RUN_SPEED, TASK_TYPES, RESOURCE_TYPES, HEALTH_REGEN_RATE } from './constants.js';
+import { SLEEP_GAIN_RATE, SETTLER_RUN_SPEED, TASK_TYPES, RESOURCE_TYPES, HEALTH_REGEN_RATE, BUILDING_TYPES } from './constants.js';
 
 export default class Settler {
     constructor(name, x, y, resourceManager, map, roomManager, spriteManager, allSettlers = null) {
@@ -224,7 +224,7 @@ export default class Settler {
         }
 
         if (this.state === "seeking_sleep" && !this.currentTask) {
-            const beds = (this.map.buildings || []).filter(b => b.type === 'bed' && (!b.occupant || b.occupant === this));
+            const beds = (this.map.buildings || []).filter(b => b.type === BUILDING_TYPES.BED && (!b.occupant || b.occupant === this));
             if (beds.length > 0) {
                 const bed = beds[0];
                 bed.occupant = this;

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -1,5 +1,5 @@
 
-import { TASK_TYPES, RESOURCE_TYPES } from './constants.js';
+import { TASK_TYPES, RESOURCE_TYPES, BUILDING_TYPES } from './constants.js';
 
 export default class UI {
     constructor(ctx) {
@@ -399,16 +399,16 @@ export default class UI {
 
         switch (categoryId) {
             case 'buildings':
-                createButton('Build Wall', 'wall', false, 'Builds a defensive wall.');
-                createButton('Build Floor', 'floor', false, 'Lays down a floor tile.');
-                createButton('Build Crafting Station', 'crafting_station', false, 'Allows settlers to craft items.');
-                createButton('Build Farm Plot', 'farm_plot', false, 'Used for growing crops.');
-                createButton('Build Animal Pen', 'animal_pen', false, 'Houses livestock.');
-                createButton('Build Barricade', 'barricade', false, 'A simple defensive barrier.');
+                createButton('Build Wall', BUILDING_TYPES.WALL, false, 'Builds a defensive wall.');
+                createButton('Build Floor', BUILDING_TYPES.FLOOR, false, 'Lays down a floor tile.');
+                createButton('Build Crafting Station', BUILDING_TYPES.CRAFTING_STATION, false, 'Allows settlers to craft items.');
+                createButton('Build Farm Plot', BUILDING_TYPES.FARM_PLOT, false, 'Used for growing crops.');
+                createButton('Build Animal Pen', BUILDING_TYPES.ANIMAL_PEN, false, 'Houses livestock.');
+                createButton('Build Barricade', BUILDING_TYPES.BARRICADE, false, 'A simple defensive barrier.');
                 break;
             case 'furniture':
-                createButton('Place Bed', 'bed', false, 'Provides a place for settlers to sleep.');
-                createButton('Place Table', 'table', false, 'A surface for various activities.');
+                createButton('Place Bed', BUILDING_TYPES.BED, false, 'Provides a place for settlers to sleep.');
+                createButton('Place Table', BUILDING_TYPES.TABLE, false, 'A surface for various activities.');
                 break;
             case 'zones':
                 createButton('Designate Bedroom', 'bedroom', true, 'Designates an area as a bedroom.');


### PR DESCRIPTION
## Summary
- define `BUILDING_TYPES` in `constants.js`
- reference `BUILDING_TYPES` across source files
- update tests to use new constant names

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6886661f84708323962d8a640802dbdf