### PR TITLE
Implement path blocking and passable property

### DIFF
--- a/__tests__/Building.test.js
+++ b/__tests__/Building.test.js
@@ -4,6 +4,16 @@ import { BUILDING_TYPES } from '../src/js/constants.js';
 import Map from '../src/js/map.js';
 
 describe('Building', () => {
+    test('passable property defaults to true', () => {
+        const building = new Building(BUILDING_TYPES.BARRICADE, 0, 0, 1, 1, 'wood', 100);
+        expect(building.passable).toBe(true);
+    });
+
+    test('wall building is not passable', () => {
+        const building = new Building(BUILDING_TYPES.WALL, 0, 0, 1, 1, 'wood', 0, 1, false);
+        expect(building.passable).toBe(false);
+    });
+
     test('takeDamage reduces health and does not go below zero', () => {
         const building = new Building(BUILDING_TYPES.BARRICADE, 0, 0, 1, 1, 'wood', 100);
         building.takeDamage(30);

--- a/__tests__/Enemy.test.js
+++ b/__tests__/Enemy.test.js
@@ -13,7 +13,11 @@ describe('Enemy', () => {
             removeResource: jest.fn(),
             getResourceQuantity: jest.fn().mockReturnValue(0)
         };
-        mockMap = { removeResourceNode: jest.fn() };
+        mockMap = {
+            removeResourceNode: jest.fn(),
+            isTileWalkable: () => true,
+            findPath: (sx, sy, ex, ey) => [{ x: ex, y: ey }]
+        };
         mockRoomManager = { rooms: [], getRoomAt: jest.fn(), addResourceToStorage: jest.fn() };
     });
 

--- a/__tests__/Game.test.js
+++ b/__tests__/Game.test.js
@@ -134,7 +134,8 @@ describe('Game', () => {
             1,
             'wood',
             0,
-            1
+            1,
+            false
         );
         expect(game.taskManager.addTask).toHaveBeenCalledTimes(2);
         expect(Task).toHaveBeenCalledWith(

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -2,7 +2,7 @@ import ResourcePile from './resourcePile.js';
 import { RESOURCE_TYPES } from './constants.js';
 
 export default class Building {
-    constructor(type, x, y, width, height, material, buildProgress, resourcesRequired = 1) {
+    constructor(type, x, y, width, height, material, buildProgress, resourcesRequired = 1, passable = true) {
         this.type = type; // e.g., "wall", "floor", "house"
         this.x = x;
         this.y = y;
@@ -12,6 +12,7 @@ export default class Building {
         this.buildProgress = buildProgress; // 0-100, 100 means built
         this.maxHealth = 100; // Max health for destruction
         this.health = this.maxHealth; // Current health
+        this.passable = passable; // Whether units can walk through this building
 
         // New properties for resource delivery
         this.resourcesRequired = resourcesRequired;
@@ -105,7 +106,8 @@ export default class Building {
             resourcesDelivered: this.resourcesDelivered,
             maxHealth: this.maxHealth,
             health: this.health,
-            inventory: this.inventory
+            inventory: this.inventory,
+            passable: this.passable
         };
     }
 
@@ -122,5 +124,6 @@ export default class Building {
         this.maxHealth = data.maxHealth;
         this.health = data.health;
         this.inventory = data.inventory || {};
+        this.passable = data.passable ?? true;
     }
 }

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -668,7 +668,7 @@ export default class Game {
             } else if (this.selectedBuilding === BUILDING_TYPES.BARRICADE) {
                 newBuilding = new Building(BUILDING_TYPES.BARRICADE, tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 0); // Barricade is a simple building
             } else if (this.selectedBuilding === BUILDING_TYPES.WALL) {
-                newBuilding = new Building(BUILDING_TYPES.WALL, tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 0, 1); // Walls require 1 wood
+                newBuilding = new Building(BUILDING_TYPES.WALL, tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 0, 1, false); // Walls require 1 wood and are impassable
             } else {
                 newBuilding = new Building(this.selectedBuilding, tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 0); // Start with 0 health
             }


### PR DESCRIPTION
## Summary
- add `passable` field to `Building`
- block movement on impassable buildings via `Map.isTileWalkable`
- implement simple pathfinding and use it for settlers and enemies
- mark walls as not passable
- update tests for new behaviour and add coverage

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68866b7f28348323b3e6b87419868914