### PR TITLE
Fix path generation and execution

### DIFF
--- a/src/js/pathfinding.js
+++ b/src/js/pathfinding.js
@@ -1,6 +1,9 @@
 
 // A* pathfinding algorithm
 export function findPath(start, end, map) {
+    if (start.x === end.x && start.y === end.y) {
+        return [];
+    }
     const openSet = [start];
     const closedSet = [];
     const cameFrom = {};
@@ -20,7 +23,7 @@ export function findPath(start, end, map) {
         }
 
         if (current.x === end.x && current.y === end.y) {
-            return reconstructPath(cameFrom, current);
+            return reconstructPath(cameFrom, current).slice(1);
         }
 
         openSet.splice(openSet.indexOf(current), 1);

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -273,6 +273,15 @@ export default class Settler {
         // Execute current task
         if (this.currentTask) {
             if (!this.path) {
+                if (Math.floor(this.x) === this.currentTask.targetX && Math.floor(this.y) === this.currentTask.targetY) {
+                    this.path = [];
+                } else {
+                    this.path = findPath({ x: Math.floor(this.x), y: Math.floor(this.y) }, { x: this.currentTask.targetX, y: this.currentTask.targetY }, this.map);
+                    if (!this.path) {
+                        this.path = [{ x: this.currentTask.targetX, y: this.currentTask.targetY }];
+                    }
+                }
+            } else if (this.path.length > 0 && (Math.abs(this.x - this.path[0].x) > 0.1 || Math.abs(this.y - this.path[0].y) > 0.1)) {
                 this.path = findPath({ x: Math.floor(this.x), y: Math.floor(this.y) }, { x: this.currentTask.targetX, y: this.currentTask.targetY }, this.map);
             }
 


### PR DESCRIPTION
## Summary
- handle zero-length paths in `findPath`
- exclude the starting node from returned paths
- recompute or fall back to direct paths when executing settler tasks

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_68867f34fd5c8323b257277555a9bf04