### PR TITLE
Fix pathfinding from water tiles

### DIFF
--- a/__tests__/Pathfinding.test.js
+++ b/__tests__/Pathfinding.test.js
@@ -1,0 +1,29 @@
+import { findPath } from '../src/js/pathfinding.js';
+
+class MockMap {
+    constructor(tiles) {
+        this.tiles = tiles;
+        this.width = tiles[0].length;
+        this.height = tiles.length;
+    }
+    getTile(x, y) {
+        return this.tiles[y][x];
+    }
+}
+
+describe('findPath with water start', () => {
+    test('allows exiting water but not entering it', () => {
+        const tiles = [
+            [0, 0, 0],
+            [0, 8, 0],
+            [0, 0, 0],
+        ];
+        const map = new MockMap(tiles);
+        // Start in water and move to dry land
+        const path1 = findPath({ x: 1, y: 1 }, { x: 0, y: 1 }, map);
+        expect(path1).toEqual([{ x: 0, y: 1 }]);
+        // Moving from land into water should fail
+        const path2 = findPath({ x: 0, y: 1 }, { x: 1, y: 1 }, map);
+        expect(path2).toBeNull();
+    });
+});

--- a/__tests__/SettlerPathfinding.test.js
+++ b/__tests__/SettlerPathfinding.test.js
@@ -1,0 +1,34 @@
+import Settler from '../src/js/settler.js';
+import Task from '../src/js/task.js';
+import { findPath } from '../src/js/pathfinding.js';
+
+jest.mock('../src/js/pathfinding.js', () => ({
+    findPath: jest.fn((start, end) => {
+        const path = [];
+        let x = start.x;
+        while (x !== end.x) {
+            x += end.x > x ? 1 : -1;
+            path.push({ x, y: start.y });
+        }
+        return path;
+    })
+}));
+
+describe('Settler pathfinding frequency', () => {
+    test('findPath called once per tile moved', () => {
+        const mockResourceManager = { addResource: jest.fn(), removeResource: jest.fn(), getResourceQuantity: jest.fn() };
+        const mockMap = { getTile: jest.fn(() => 0), width: 10, height: 10, resourcePiles: [], addResourcePile: jest.fn(), tileSize: 1, buildings: [] };
+        const mockRoomManager = { getRoomAt: jest.fn(), addResourceToStorage: jest.fn(), findStorageRoomAndTile: jest.fn(), rooms: [] };
+        const settler = new Settler('Test', 0, 0, mockResourceManager, mockMap, mockRoomManager);
+        const task = new Task('move', 2, 0);
+        settler.currentTask = task;
+
+        for (let i = 0; i < 5; i++) {
+            settler.updateNeeds(1000);
+        }
+
+        expect(findPath).toHaveBeenCalledTimes(2);
+        expect(settler.x).toBe(2);
+        expect(settler.y).toBe(0);
+    });
+});

--- a/src/js/pathfinding.js
+++ b/src/js/pathfinding.js
@@ -61,10 +61,31 @@ function getNeighbors(node, map) {
     const neighbors = [];
     const { x, y } = node;
 
-    if (x > 0 && map.getTile(x - 1, y) !== 8) neighbors.push({ x: x - 1, y });
-    if (x < map.width - 1 && map.getTile(x + 1, y) !== 8) neighbors.push({ x: x + 1, y });
-    if (y > 0 && map.getTile(x, y - 1) !== 8) neighbors.push({ x, y: y - 1 });
-    if (y < map.height - 1 && map.getTile(x, y + 1) !== 8) neighbors.push({ x, y: y + 1 });
+    const currentTile = map.getTile ? map.getTile(x, y) : 0;
+    const isUnpassable = currentTile === 8;
+
+    const checkAndAdd = (nx, ny) => {
+        if (
+            nx >= 0 && nx < map.width && ny >= 0 && ny < map.height &&
+            (map.getTile ? map.getTile(nx, ny) : 0) !== 8
+        ) {
+            neighbors.push({ x: nx, y: ny });
+        }
+    };
+
+    // Cardinal directions
+    checkAndAdd(x - 1, y);
+    checkAndAdd(x + 1, y);
+    checkAndAdd(x, y - 1);
+    checkAndAdd(x, y + 1);
+
+    // If current tile is un-passable, allow diagonal escape
+    if (isUnpassable) {
+        checkAndAdd(x - 1, y - 1);
+        checkAndAdd(x - 1, y + 1);
+        checkAndAdd(x + 1, y - 1);
+        checkAndAdd(x + 1, y + 1);
+    }
 
     return neighbors;
 }

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -281,8 +281,6 @@ export default class Settler {
                         this.path = [{ x: this.currentTask.targetX, y: this.currentTask.targetY }];
                     }
                 }
-            } else if (this.path.length > 0 && (Math.abs(this.x - this.path[0].x) > 0.1 || Math.abs(this.y - this.path[0].y) > 0.1)) {
-                this.path = findPath({ x: Math.floor(this.x), y: Math.floor(this.y) }, { x: this.currentTask.targetX, y: this.currentTask.targetY }, this.map);
             }
 
             if (this.path && this.path.length > 0) {
@@ -303,6 +301,7 @@ export default class Settler {
                     this.x = targetNode.x;
                     this.y = targetNode.y;
                     this.path.shift();
+                    this.path = null; // recalc on next tile
                 }
             } else {
                 // Check if arrived at target


### PR DESCRIPTION
## Summary
- allow settlers to escape un-passable water tiles via diagonals
- handle maps without `getTile` when pathfinding is mocked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688680dcd7dc832380844edd87b663bd