### PR TITLE
Add passable property to buildings and update pathfinding

### DIFF
--- a/__tests__/Pathfinding.test.js
+++ b/__tests__/Pathfinding.test.js
@@ -1,13 +1,18 @@
 import { findPath } from '../src/js/pathfinding.js';
+import { BUILDING_TYPES } from '../src/js/constants.js';
 
 class MockMap {
-    constructor(tiles) {
+    constructor(tiles, buildings = []) {
         this.tiles = tiles;
+        this.buildings = buildings;
         this.width = tiles[0].length;
         this.height = tiles.length;
     }
     getTile(x, y) {
         return this.tiles[y][x];
+    }
+    getBuildingAt(x, y) {
+        return this.buildings.find(b => b.x === x && b.y === y) || null;
     }
 }
 
@@ -25,5 +30,20 @@ describe('findPath with water start', () => {
         // Moving from land into water should fail
         const path2 = findPath({ x: 0, y: 1 }, { x: 1, y: 1 }, map);
         expect(path2).toBeNull();
+    });
+});
+
+describe('findPath with buildings', () => {
+    test('walls block movement', () => {
+        const tiles = [
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+        ];
+        const buildings = [{ x: 1, y: 1, type: BUILDING_TYPES.WALL }];
+        const map = new MockMap(tiles, buildings);
+        const path = findPath({ x: 0, y: 1 }, { x: 2, y: 1 }, map);
+        expect(path).not.toBeNull();
+        expect(path.some(p => p.x === 1 && p.y === 1)).toBe(false);
     });
 });

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -1,5 +1,5 @@
 import ResourcePile from './resourcePile.js';
-import { RESOURCE_TYPES } from './constants.js';
+import { RESOURCE_TYPES, BUILDING_TYPE_PROPERTIES } from './constants.js';
 
 export default class Building {
     constructor(type, x, y, width, height, material, buildProgress, resourcesRequired = 1) {
@@ -12,6 +12,7 @@ export default class Building {
         this.buildProgress = buildProgress; // 0-100, 100 means built
         this.maxHealth = 100; // Max health for destruction
         this.health = this.maxHealth; // Current health
+        this.passable = BUILDING_TYPE_PROPERTIES[this.type]?.passable ?? true;
 
         // New properties for resource delivery
         this.resourcesRequired = resourcesRequired;
@@ -105,7 +106,8 @@ export default class Building {
             resourcesDelivered: this.resourcesDelivered,
             maxHealth: this.maxHealth,
             health: this.health,
-            inventory: this.inventory
+            inventory: this.inventory,
+            passable: this.passable
         };
     }
 
@@ -122,5 +124,6 @@ export default class Building {
         this.maxHealth = data.maxHealth;
         this.health = data.health;
         this.inventory = data.inventory || {};
+        this.passable = data.passable ?? BUILDING_TYPE_PROPERTIES[this.type]?.passable ?? true;
     }
 }

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -17,6 +17,18 @@ export const BUILDING_TYPES = {
   TABLE: 'table'
 };
 
+// Properties for each building type
+export const BUILDING_TYPE_PROPERTIES = {
+  [BUILDING_TYPES.WALL]: { passable: false },
+  [BUILDING_TYPES.FLOOR]: { passable: true },
+  [BUILDING_TYPES.CRAFTING_STATION]: { passable: true },
+  [BUILDING_TYPES.FARM_PLOT]: { passable: true },
+  [BUILDING_TYPES.ANIMAL_PEN]: { passable: true },
+  [BUILDING_TYPES.BARRICADE]: { passable: true },
+  [BUILDING_TYPES.BED]: { passable: true },
+  [BUILDING_TYPES.TABLE]: { passable: true }
+};
+
 // Resource types used throughout the game
 export const RESOURCE_TYPES = {
   WOOD: 'wood',

--- a/src/js/pathfinding.js
+++ b/src/js/pathfinding.js
@@ -1,4 +1,6 @@
 
+import { BUILDING_TYPE_PROPERTIES } from './constants.js';
+
 // A* pathfinding algorithm
 export function findPath(start, end, map) {
     if (start.x === end.x && start.y === end.y) {
@@ -62,14 +64,31 @@ function getNeighbors(node, map) {
     const { x, y } = node;
 
     const currentTile = map.getTile ? map.getTile(x, y) : 0;
-    const isUnpassable = currentTile === 8;
+    const currentBuilding = map.getBuildingAt ? map.getBuildingAt(x, y) : null;
+    const isUnpassable =
+        currentTile === 8 ||
+        (currentBuilding &&
+            BUILDING_TYPE_PROPERTIES[currentBuilding.type] &&
+            BUILDING_TYPE_PROPERTIES[currentBuilding.type].passable === false);
 
     const checkAndAdd = (nx, ny) => {
         if (
-            nx >= 0 && nx < map.width && ny >= 0 && ny < map.height &&
+            nx >= 0 &&
+            nx < map.width &&
+            ny >= 0 &&
+            ny < map.height &&
             (map.getTile ? map.getTile(nx, ny) : 0) !== 8
         ) {
-            neighbors.push({ x: nx, y: ny });
+            const b = map.getBuildingAt ? map.getBuildingAt(nx, ny) : null;
+            if (
+                !b ||
+                !(
+                    BUILDING_TYPE_PROPERTIES[b.type] &&
+                    BUILDING_TYPE_PROPERTIES[b.type].passable === false
+                )
+            ) {
+                neighbors.push({ x: nx, y: ny });
+            }
         }
     };
 


### PR DESCRIPTION
## Summary
- define `BUILDING_TYPE_PROPERTIES` describing passability of each building type
- include `passable` field in `Building` instances and serialization
- update pathfinding to consider buildings that are not passable
- extend pathfinding tests for wall obstruction

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6886898cbae083239cf41fb1a2f41897