### PR TITLE
Add pathfinding for enemies

### DIFF
--- a/__tests__/Enemy.test.js
+++ b/__tests__/Enemy.test.js
@@ -23,7 +23,7 @@ describe('Enemy', () => {
         target.equipArmor(helmet);
         jest.spyOn(target, 'takeDamage');
 
-        const enemy = new Enemy('Raider', 0, 0, target);
+        const enemy = new Enemy('Raider', 0, 0, target, mockMap);
         const originalRandom = Math.random;
         Math.random = () => 0; // Hit head
         enemy.dealDamage(target);
@@ -34,7 +34,7 @@ describe('Enemy', () => {
 
     test('update attacks target when in range', () => {
         const target = new Settler('Target', 0, 0, mockResourceManager, mockMap, mockRoomManager);
-        const enemy = new Enemy('Raider', 0, 0, target);
+        const enemy = new Enemy('Raider', 0, 0, target, mockMap);
         enemy.attackCooldown = 0;
         jest.spyOn(enemy, 'dealDamage').mockImplementation(() => {});
 

--- a/__tests__/SettlerCombat.test.js
+++ b/__tests__/SettlerCombat.test.js
@@ -68,7 +68,7 @@ describe('Settler Health and Combat', () => {
     });
 
     test('settler stops task and targets attacker when hit', () => {
-        const enemy = new Enemy('Goblin', 1, 1, null, { getSprite: jest.fn() });
+        const enemy = new Enemy('Goblin', 1, 1, null, mockMap, { getSprite: jest.fn() });
         settler.currentTask = { type: 'move', targetX: 5, targetY: 5 };
         settler.state = 'idle';
 
@@ -85,7 +85,7 @@ describe('Settler Health and Combat', () => {
         const bob = new Settler('Bob', 1, 1, mockResourceManager, mockMap, mockRoomManager, undefined, settlers);
         settlers.push(alice, bob);
 
-        const enemy = new Enemy('Goblin', 1, 1, null, { getSprite: jest.fn() });
+        const enemy = new Enemy('Goblin', 1, 1, null, mockMap, { getSprite: jest.fn() });
 
         alice.takeDamage('torso', 5, false, enemy);
 

--- a/src/js/eventManager.js
+++ b/src/js/eventManager.js
@@ -25,7 +25,17 @@ export default class EventManager {
                     // Spawn a new enemy
                     if (this.game.settlers.length > 0) {
                         const targetSettler = this.game.settlers[Math.floor(Math.random() * this.game.settlers.length)];
-                        this.game.enemies.push(new this.EnemyClass("Wild Boar", 49, 29, targetSettler, this.game.spriteManager, RESOURCE_TYPES.MEAT));
+                        this.game.enemies.push(
+                            new this.EnemyClass(
+                                "Wild Boar",
+                                49,
+                                29,
+                                targetSettler,
+                                this.game.map,
+                                this.game.spriteManager,
+                                RESOURCE_TYPES.MEAT
+                            )
+                        );
                         debugLog("A wild boar has appeared!");
                     this.game.notificationManager.addNotification("A wild boar has appeared!", 'warning');
                     }
@@ -89,7 +99,16 @@ export default class EventManager {
                     this.game.notificationManager.addNotification("A vile force of darkness has arrived!", 'warning');
                     if (this.game.settlers.length > 0) {
                         const targetSettler = this.game.settlers[Math.floor(Math.random() * this.game.settlers.length)];
-                        this.game.enemies.push(new this.EnemyClass("Goblin", 49, 29, targetSettler, this.game.spriteManager));
+                        this.game.enemies.push(
+                            new this.EnemyClass(
+                                "Goblin",
+                                49,
+                                29,
+                                targetSettler,
+                                this.game.map,
+                                this.game.spriteManager
+                            )
+                        );
                         debugLog("A goblin has appeared!");
                         this.game.notificationManager.addNotification("A goblin has appeared!", 'warning');
                     }

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -562,7 +562,14 @@ export default class Game {
 
             // Restore enemies
             this.enemies = gameState.enemies.map(eData => {
-                const enemy = new Enemy(eData.name, eData.x, eData.y, null, this.spriteManager); // Target settler will be re-assigned in update
+                const enemy = new Enemy(
+                    eData.name,
+                    eData.x,
+                    eData.y,
+                    null,
+                    this.map,
+                    this.spriteManager
+                ); // Target settler will be re-assigned in update
                 enemy.deserialize(eData);
                 return enemy;
             });


### PR DESCRIPTION
## Summary
- make enemies use same pathfinding logic as settlers
- spawn enemies with map reference for pathfinding
- adapt game loading logic for new Enemy signature
- update tests for new constructor

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68868c6730a88323b7ef954813161e2f