### PR TITLE
Ensure single-haul per craft

### DIFF
--- a/src/js/game.js
+++ b/src/js/game.js
@@ -465,27 +465,23 @@ export default class Game {
     }
 
     addCraftTask(craftingStation, recipe, quantity = 1) {
-        // Ensure required resources get delivered to the station
-        recipe.inputs.forEach(input => {
-            const existing = craftingStation.getResourceQuantity(input.resourceType);
-            const required = input.quantity * quantity;
-            const missing = required - existing;
-            if (missing > 0) {
+        // Queue hauling and crafting tasks individually so settlers
+        // only carry one set of inputs and craft one item at a time
+        for (let i = 0; i < quantity; i++) {
+            recipe.inputs.forEach(input => {
                 this.taskManager.addTask(
                     new Task(
                         TASK_TYPES.HAUL,
                         craftingStation.x,
                         craftingStation.y,
                         input.resourceType,
-                        missing,
+                        input.quantity,
                         3,
                         craftingStation,
                     ),
                 );
-            }
-        });
+            });
 
-        for (let i = 0; i < quantity; i++) {
             this.taskManager.addTask(
                 new Task(
                     TASK_TYPES.CRAFT,


### PR DESCRIPTION
## Summary
- send one haul task per craft input in `addCraftTask`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886f3cba9008323b82248aa5ad74ae2