### PR TITLE
Implement task assignment tracking

### DIFF
--- a/__tests__/TaskManager.test.js
+++ b/__tests__/TaskManager.test.js
@@ -22,7 +22,7 @@ describe('TaskManager', () => {
         taskManager.addTask(task1);
         taskManager.addTask(task2);
         expect(taskManager.getTask()).toBe(task1);
-        expect(taskManager.tasks.length).toBe(1);
+        expect(taskManager.tasks.length).toBe(2);
     });
 
     test('should return null if no tasks are available', () => {
@@ -54,7 +54,7 @@ describe('TaskManager', () => {
 
         expect(task).toBe(buildTask);
         expect(taskManager.tasks).toContain(haulTask);
-        expect(taskManager.tasks).not.toContain(buildTask);
+        expect(taskManager.tasks).toContain(buildTask);
     });
 
     test('getTaskForSettler respects settler priorities', () => {
@@ -68,7 +68,7 @@ describe('TaskManager', () => {
 
         expect(task).toBe(haulTask);
         expect(taskManager.tasks).toContain(buildTask);
-        expect(taskManager.tasks).not.toContain(haulTask);
+        expect(taskManager.tasks).toContain(haulTask);
     });
 
     test('assignTasks chooses idle settler with highest priority', () => {
@@ -81,7 +81,8 @@ describe('TaskManager', () => {
 
         expect(settlerB.currentTask).toBe(buildTask);
         expect(settlerA.currentTask).toBeNull();
-        expect(taskManager.tasks.length).toBe(0);
+        expect(taskManager.tasks.length).toBe(1);
+        expect(buildTask.assigned).toBe('B');
     });
 
     test('removeTask deletes a task', () => {

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -183,6 +183,7 @@ export default class Game {
             }
 
         });
+        this.taskManager.cleanupCompletedTasks(this.settlers);
         // Task assignment handled after all settlers update
         this.taskManager.assignTasks(
             this.settlers,
@@ -579,6 +580,10 @@ export default class Game {
                 }
                 if (task.assignedSettler) {
                     task.assignedSettler = this.settlers.find(s => s.name === task.assignedSettler);
+                }
+                if (task.assigned) {
+                    const settler = this.settlers.find(s => s.name === task.assigned);
+                    if (settler) task.assigned = settler.name;
                 }
                 if (task.targetLocation) {
                     task.targetLocation = this.worldMap.getLocation(task.targetLocation.id);

--- a/src/js/task.js
+++ b/src/js/task.js
@@ -9,6 +9,7 @@ export default class Task {
         this.building = building; // For building tasks (e.g., build task, or crafting station for craft task)
         this.recipe = recipe; // For craft tasks
         this.assignedSettler = null;
+        this.assigned = null; // identifier of the settler assigned to this task
         this.craftingProgress = 0; // For craft tasks
         this.cropType = cropType; // For sow_crop tasks
         this.targetLocation = targetLocation; // For explore tasks
@@ -30,6 +31,7 @@ export default class Task {
             building: this.building ? { type: this.building.type, x: this.building.x, y: this.building.y } : null,
             recipe: this.recipe ? { name: this.recipe.name } : null,
             assignedSettler: this.assignedSettler ? this.assignedSettler.name : null,
+            assigned: this.assigned,
             craftingProgress: this.craftingProgress,
             cropType: this.cropType,
             targetLocation: this.targetLocation ? { id: this.targetLocation.id } : null,
@@ -52,6 +54,7 @@ export default class Task {
         this.building = data.building; // Store raw data for now
         this.recipe = data.recipe; // Store raw data for now
         this.assignedSettler = data.assignedSettler; // Store raw data for now
+        this.assigned = data.assigned || null;
         this.craftingProgress = data.craftingProgress;
         this.cropType = data.cropType;
         this.targetLocation = data.targetLocation; // Store raw data for now

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -554,6 +554,9 @@ export default class UI {
             const typeCell = document.createElement('td');
             typeCell.textContent = task.type;
 
+            const assignedCell = document.createElement('td');
+            assignedCell.textContent = task.assigned || '';
+
             const actionCell = document.createElement('td');
             const delBtn = document.createElement('button');
             delBtn.textContent = 'Delete';
@@ -563,6 +566,7 @@ export default class UI {
             actionCell.appendChild(delBtn);
 
             row.appendChild(typeCell);
+            row.appendChild(assignedCell);
             row.appendChild(actionCell);
             tbody.appendChild(row);
         });


### PR DESCRIPTION
## Summary
- keep tasks in the manager after they are given to settlers
- track the assigned settler name on each task
- show the assigned settler in the task manager UI
- clean up completed tasks automatically
- update unit tests for new behaviour

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688702b5a1dc83239048ba5e9309fd37