### PR TITLE
Add task unassign functionality

### DIFF
--- a/__tests__/GameUnassignTask.test.js
+++ b/__tests__/GameUnassignTask.test.js
@@ -1,0 +1,35 @@
+import Game from '../src/js/game.js';
+import Settler from '../src/js/settler.js';
+import Task from '../src/js/task.js';
+import { TASK_TYPES } from '../src/js/constants.js';
+
+describe('Game unassign task', () => {
+    test('unassignTask clears assignment and reassigns when idle settler available', () => {
+        const ctx = { canvas: { width: 800, height: 600 }, clearRect: jest.fn(), drawImage: jest.fn() };
+        const game = new Game(ctx);
+        const alice = new Settler('Alice', 0, 0, game.resourceManager, game.map, game.roomManager, game.spriteManager, game.settlers);
+        const bob = new Settler('Bob', 0, 0, game.resourceManager, game.map, game.roomManager, game.spriteManager, game.settlers);
+        alice.updateNeeds = jest.fn();
+        bob.updateNeeds = jest.fn();
+        alice.state = 'idle';
+        bob.state = 'idle';
+        game.settlers = [alice, bob];
+        game.roomManager.setSettlers(game.settlers);
+
+        const task = new Task(TASK_TYPES.BUILD, 1, 1);
+        game.taskManager.addTask(task);
+
+        game.update(16);
+
+        expect(task.assigned).toBe('Alice');
+        expect(alice.currentTask).toBe(task);
+        expect(bob.currentTask).toBeNull();
+
+        alice.state = 'busy';
+        game.unassignTask(task);
+
+        expect(alice.currentTask).toBeNull();
+        expect(task.assigned).toBe('Bob');
+        expect(bob.currentTask).toBe(task);
+    });
+});

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -498,6 +498,31 @@ export default class Game {
         }
     }
 
+    unassignTask(task) {
+        if (!task.assigned) return;
+        const settler = this.settlers.find(s => s.name === task.assigned);
+        if (settler && settler.currentTask === task) {
+            if (settler.currentBuilding && settler.currentBuilding === task.building) {
+                settler.currentBuilding.occupant = null;
+                settler.currentBuilding = null;
+            }
+            settler.currentTask = null;
+        }
+        if (task.building && task.building.occupant === settler) {
+            task.building.occupant = null;
+        }
+        task.assigned = null;
+        task.assignedSettler = null;
+        this.taskManager.notifyChange();
+        this.taskManager.assignTasks(
+            this.settlers,
+            (t, s) => !(
+                s.carrying &&
+                (t.type === TASK_TYPES.HAUL || GATHER_TASK_TYPES.has(t.type))
+            )
+        );
+    }
+
     saveGame() {
         const gameState = {
             settlers: this.settlers.map(settler => settler.serialize()),

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -565,6 +565,13 @@ export default class UI {
             };
             actionCell.appendChild(delBtn);
 
+            const unassignBtn = document.createElement('button');
+            unassignBtn.textContent = 'Unassign';
+            unassignBtn.onclick = () => {
+                this.gameInstance.unassignTask(task);
+            };
+            actionCell.appendChild(unassignBtn);
+
             row.appendChild(typeCell);
             row.appendChild(assignedCell);
             row.appendChild(actionCell);


### PR DESCRIPTION
## Summary
- add Unassign button in Task Manager UI
- implement Game.unassignTask to clear assignments and reassign
- test unassignTask behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688706a6c2748323a2b71347e4333261