### PR TITLE
Ensure settlers stop work when tasks are deleted

### DIFF
--- a/__tests__/GameDeleteTask.test.js
+++ b/__tests__/GameDeleteTask.test.js
@@ -1,0 +1,30 @@
+import Game from '../src/js/game.js';
+import Settler from '../src/js/settler.js';
+import Task from '../src/js/task.js';
+import { TASK_TYPES } from '../src/js/constants.js';
+
+describe('Game delete task', () => {
+    test('deleteTask unassigns the settler', () => {
+        const ctx = { canvas: { width: 800, height: 600 }, clearRect: jest.fn(), drawImage: jest.fn() };
+        const game = new Game(ctx);
+        const alice = new Settler('Alice', 0, 0, game.resourceManager, game.map, game.roomManager, game.spriteManager, game.settlers);
+        alice.updateNeeds = jest.fn();
+        alice.state = 'idle';
+        game.settlers = [alice];
+        game.roomManager.setSettlers(game.settlers);
+
+        const task = new Task(TASK_TYPES.BUILD, 1, 1);
+        game.taskManager.addTask(task);
+
+        game.update(16);
+
+        expect(task.assigned).toBe('Alice');
+        expect(alice.currentTask).toBe(task);
+
+        game.deleteTask(task);
+
+        expect(alice.currentTask).toBeNull();
+        expect(task.assigned).toBeNull();
+        expect(game.taskManager.tasks).not.toContain(task);
+    });
+});

--- a/__tests__/UI.test.js
+++ b/__tests__/UI.test.js
@@ -99,7 +99,10 @@ describe('UI tooltips', () => {
                 }
             }),
         };
-        const mockGame = { taskManager: mockTaskManager };
+        const mockGame = { 
+            taskManager: mockTaskManager,
+            deleteTask: jest.fn(task => mockTaskManager.removeTask(task)),
+        };
         ui.setGameInstance(mockGame);
         ui.showTaskManager();
         expect(ui.taskOverlay.style.display).toBe('block');
@@ -107,7 +110,7 @@ describe('UI tooltips', () => {
         expect(ui.taskOverlay.querySelectorAll('table tr').length).toBe(2);
         const deleteButtons = ui.taskOverlay.querySelectorAll('table button');
         deleteButtons[0].dispatchEvent(new Event('click'));
-        expect(mockTaskManager.removeTask).toHaveBeenCalledWith(task1);
+        expect(mockGame.deleteTask).toHaveBeenCalledWith(task1);
         expect(ui.taskOverlay.querySelectorAll('table tr').length).toBe(1);
         ui.hideTaskManager();
         expect(ui.taskOverlay.style.display).toBe('none');

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -523,6 +523,11 @@ export default class Game {
         );
     }
 
+    deleteTask(task) {
+        this.taskManager.removeTask(task);
+        this.unassignTask(task);
+    }
+
     saveGame() {
         const gameState = {
             settlers: this.settlers.map(settler => settler.serialize()),

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -561,7 +561,7 @@ export default class UI {
             const delBtn = document.createElement('button');
             delBtn.textContent = 'Delete';
             delBtn.onclick = () => {
-                this.gameInstance.taskManager.removeTask(task);
+                this.gameInstance.deleteTask(task);
             };
             actionCell.appendChild(delBtn);
 


### PR DESCRIPTION
## Summary
- add `deleteTask` in `Game` to remove and unassign a task
- call new method from UI when the Delete button is pressed
- adjust UI tests for new behavior
- add test verifying that deleting a task clears the assigned settler

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688708978adc83239350de821cab894c