### PR TITLE
Implement task pausing

### DIFF
--- a/__tests__/GamePauseTask.test.js
+++ b/__tests__/GamePauseTask.test.js
@@ -1,0 +1,39 @@
+import Game from '../src/js/game.js';
+import Settler from '../src/js/settler.js';
+import Task from '../src/js/task.js';
+import { TASK_TYPES } from '../src/js/constants.js';
+
+describe('Game pause task', () => {
+    test('pauseTask unassigns settler and prevents reassignment until unpaused', () => {
+        const ctx = { canvas: { width: 800, height: 600 }, clearRect: jest.fn(), drawImage: jest.fn() };
+        const game = new Game(ctx);
+        const alice = new Settler('Alice', 0, 0, game.resourceManager, game.map, game.roomManager, game.spriteManager, game.settlers);
+        const bob = new Settler('Bob', 0, 0, game.resourceManager, game.map, game.roomManager, game.spriteManager, game.settlers);
+        alice.updateNeeds = jest.fn();
+        bob.updateNeeds = jest.fn();
+        alice.state = 'idle';
+        bob.state = 'idle';
+        game.settlers = [alice, bob];
+        game.roomManager.setSettlers(game.settlers);
+
+        const task = new Task(TASK_TYPES.BUILD, 1, 1);
+        game.taskManager.addTask(task);
+
+        game.update(16);
+
+        expect(task.assigned).toBe('Alice');
+        expect(alice.currentTask).toBe(task);
+
+        game.pauseTask(task);
+
+        expect(task.paused).toBe(true);
+        expect(task.assigned).toBeNull();
+        expect(alice.currentTask).toBeNull();
+        expect(bob.currentTask).toBeNull();
+
+        game.unpauseTask(task);
+
+        expect(task.paused).toBe(false);
+        expect(task.assigned).toBe('Alice');
+    });
+});

--- a/__tests__/UI.test.js
+++ b/__tests__/UI.test.js
@@ -99,9 +99,12 @@ describe('UI tooltips', () => {
                 }
             }),
         };
-        const mockGame = { 
+        const mockGame = {
             taskManager: mockTaskManager,
             deleteTask: jest.fn(task => mockTaskManager.removeTask(task)),
+            unassignTask: jest.fn(),
+            pauseTask: jest.fn(),
+            unpauseTask: jest.fn(),
         };
         ui.setGameInstance(mockGame);
         ui.showTaskManager();
@@ -112,6 +115,10 @@ describe('UI tooltips', () => {
         deleteButtons[0].dispatchEvent(new Event('click'));
         expect(mockGame.deleteTask).toHaveBeenCalledWith(task1);
         expect(ui.taskOverlay.querySelectorAll('table tr').length).toBe(1);
+        const pauseButtons = Array.from(ui.taskOverlay.querySelectorAll('table button')).filter(b => b.textContent === 'Pause');
+        expect(pauseButtons.length).toBe(1);
+        pauseButtons[0].dispatchEvent(new Event('click'));
+        expect(mockGame.pauseTask).toHaveBeenCalledWith(task2);
         ui.hideTaskManager();
         expect(ui.taskOverlay.style.display).toBe('none');
         expect(mockTaskManager.removeChangeListener).toHaveBeenCalled();

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -87,7 +87,7 @@ canvas {
     position: fixed;
     bottom: 10px;
     right: 10px;
-    width: 250px;
+    width: 500px;
     height: 400px;
     background-color: rgba(0, 0, 0, 0.8);
     color: white;

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -523,6 +523,26 @@ export default class Game {
         );
     }
 
+    pauseTask(task) {
+        if (task.paused) return;
+        task.paused = true;
+        this.unassignTask(task);
+        this.taskManager.notifyChange();
+    }
+
+    unpauseTask(task) {
+        if (!task.paused) return;
+        task.paused = false;
+        this.taskManager.assignTasks(
+            this.settlers,
+            (t, s) => !(
+                s.carrying &&
+                (t.type === TASK_TYPES.HAUL || GATHER_TASK_TYPES.has(t.type))
+            )
+        );
+        this.taskManager.notifyChange();
+    }
+
     deleteTask(task) {
         this.taskManager.removeTask(task);
         this.unassignTask(task);

--- a/src/js/task.js
+++ b/src/js/task.js
@@ -10,6 +10,7 @@ export default class Task {
         this.recipe = recipe; // For craft tasks
         this.assignedSettler = null;
         this.assigned = null; // identifier of the settler assigned to this task
+        this.paused = false; // when true, task will not be assigned
         this.craftingProgress = 0; // For craft tasks
         this.cropType = cropType; // For sow_crop tasks
         this.targetLocation = targetLocation; // For explore tasks
@@ -32,6 +33,7 @@ export default class Task {
             recipe: this.recipe ? { name: this.recipe.name } : null,
             assignedSettler: this.assignedSettler ? this.assignedSettler.name : null,
             assigned: this.assigned,
+            paused: this.paused,
             craftingProgress: this.craftingProgress,
             cropType: this.cropType,
             targetLocation: this.targetLocation ? { id: this.targetLocation.id } : null,
@@ -56,6 +58,7 @@ export default class Task {
         this.assignedSettler = data.assignedSettler; // Store raw data for now
         this.assigned = data.assigned || null;
         this.craftingProgress = data.craftingProgress;
+        this.paused = data.paused || false;
         this.cropType = data.cropType;
         this.targetLocation = data.targetLocation; // Store raw data for now
         this.carrying = data.carrying;

--- a/src/js/taskManager.js
+++ b/src/js/taskManager.js
@@ -27,7 +27,7 @@ export default class TaskManager {
     getTask(filterFn = null) {
         for (let i = 0; i < this.tasks.length; i++) {
             const task = this.tasks[i];
-            if (task.assigned) continue;
+            if (task.assigned || task.paused) continue;
             if (!filterFn || filterFn(task)) {
                 return task;
             }
@@ -38,7 +38,7 @@ export default class TaskManager {
     getTaskForSettler(settler, filterFn = null) {
         for (let i = 0; i < this.tasks.length; i++) {
             const task = this.tasks[i];
-            if (task.assigned) continue;
+            if (task.assigned || task.paused) continue;
             if (settler.taskPriorities && settler.taskPriorities[task.type] > 0) {
                 if (!filterFn || filterFn(task)) {
                     return task;
@@ -52,7 +52,7 @@ export default class TaskManager {
         let changed = false;
         for (let i = 0; i < this.tasks.length; i++) {
             const task = this.tasks[i];
-            if (task.assigned) continue;
+            if (task.assigned || task.paused) continue;
             let bestSettler = null;
             let bestPriority = -1;
 

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -557,6 +557,9 @@ export default class UI {
             const assignedCell = document.createElement('td');
             assignedCell.textContent = task.assigned || '';
 
+            const pausedCell = document.createElement('td');
+            pausedCell.textContent = task.paused ? 'Yes' : 'No';
+
             const actionCell = document.createElement('td');
             const delBtn = document.createElement('button');
             delBtn.textContent = 'Delete';
@@ -572,8 +575,20 @@ export default class UI {
             };
             actionCell.appendChild(unassignBtn);
 
+            const pauseBtn = document.createElement('button');
+            pauseBtn.textContent = task.paused ? 'Unpause' : 'Pause';
+            pauseBtn.onclick = () => {
+                if (task.paused) {
+                    this.gameInstance.unpauseTask(task);
+                } else {
+                    this.gameInstance.pauseTask(task);
+                }
+            };
+            actionCell.appendChild(pauseBtn);
+
             row.appendChild(typeCell);
             row.appendChild(assignedCell);
+            row.appendChild(pausedCell);
             row.appendChild(actionCell);
             tbody.appendChild(row);
         });


### PR DESCRIPTION
## Summary
- add paused flag to `Task`
- skip paused tasks during assignment in `TaskManager`
- implement `pauseTask`/`unpauseTask` helpers in `Game`
- extend task manager UI with pause controls and paused column
- widen the task manager overlay
- create tests for pausing tasks

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68870b44c5a48323b1c2483aad70158c