### PR TITLE
Add task manager table header

### DIFF
--- a/__tests__/UI.test.js
+++ b/__tests__/UI.test.js
@@ -110,11 +110,11 @@ describe('UI tooltips', () => {
         ui.showTaskManager();
         expect(ui.taskOverlay.style.display).toBe('block');
         expect(ui.taskOverlay.querySelector('table')).not.toBeNull();
-        expect(ui.taskOverlay.querySelectorAll('table tr').length).toBe(2);
+        expect(ui.taskOverlay.querySelectorAll('table tr').length).toBe(3);
         const deleteButtons = ui.taskOverlay.querySelectorAll('table button');
         deleteButtons[0].dispatchEvent(new Event('click'));
         expect(mockGame.deleteTask).toHaveBeenCalledWith(task1);
-        expect(ui.taskOverlay.querySelectorAll('table tr').length).toBe(1);
+        expect(ui.taskOverlay.querySelectorAll('table tr').length).toBe(2);
         const pauseButtons = Array.from(ui.taskOverlay.querySelectorAll('table button')).filter(b => b.textContent === 'Pause');
         expect(pauseButtons.length).toBe(1);
         pauseButtons[0].dispatchEvent(new Event('click'));

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -103,6 +103,12 @@ canvas {
     border-collapse: collapse;
 }
 
+#task-overlay th {
+    text-align: left;
+    padding: 5px;
+    border-bottom: 1px solid #444;
+}
+
 #task-overlay .task-row td {
     padding: 5px;
 }

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -545,6 +545,17 @@ export default class UI {
         this.taskOverlay.appendChild(closeBtn);
 
         const table = document.createElement('table');
+
+        const thead = document.createElement('thead');
+        const headerRow = document.createElement('tr');
+        ['Type', 'Assigned', 'Paused', 'Actions'].forEach(text => {
+            const th = document.createElement('th');
+            th.textContent = text;
+            headerRow.appendChild(th);
+        });
+        thead.appendChild(headerRow);
+        table.appendChild(thead);
+
         const tbody = document.createElement('tbody');
 
         this.gameInstance.taskManager.tasks.forEach(task => {


### PR DESCRIPTION
## Summary
- add a header row in the Task Manager table UI
- style the new header row in CSS
- adjust UI tests for new header row

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68870d0f918c8323b3ab48d43c961e4a