### PR TITLE
Fix task manager scroll zoom

### DIFF
--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -225,6 +225,9 @@ export default class UI {
         this.taskOverlay.addEventListener('click', (event) => {
             event.stopPropagation();
         });
+        this.taskOverlay.addEventListener('wheel', (event) => {
+            event.stopPropagation();
+        });
         document.body.appendChild(this.taskOverlay);
 
         this.farmPlotMenu = document.createElement('div');


### PR DESCRIPTION
## Summary
- stop wheel events inside the task manager overlay from propagating

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68870e4bc6cc832399ec5b0a110e9b50