### PR TITLE
Fix initial overlay visibility

### DIFF
--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -189,6 +189,7 @@ export default class UI {
 
         this.helpOverlay = document.createElement('div');
         this.helpOverlay.id = 'help-overlay';
+        this.helpOverlay.style.display = 'none';
         const helpContent = document.createElement('div');
         helpContent.innerHTML = `
             <h2>How to Play</h2>
@@ -208,6 +209,7 @@ export default class UI {
 
         this.priorityOverlay = document.createElement('div');
         this.priorityOverlay.id = 'priority-overlay';
+        this.priorityOverlay.style.display = 'none';
         // Prevent clicks inside the overlay from reaching the game canvas
         this.priorityOverlay.addEventListener('mousedown', (event) => {
             event.stopPropagation();
@@ -219,6 +221,7 @@ export default class UI {
 
         this.taskOverlay = document.createElement('div');
         this.taskOverlay.id = 'task-overlay';
+        this.taskOverlay.style.display = 'none';
         this.taskOverlay.addEventListener('mousedown', (event) => {
             event.stopPropagation();
         });


### PR DESCRIPTION
## Summary
- set help, priority, and task overlays to `display: none` on creation so toggling works on first click

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688712364a4083239b2649f2af9cb47a