### PR TITLE
Add oven building with bread crafting

### DIFF
--- a/__tests__/Oven.test.js
+++ b/__tests__/Oven.test.js
@@ -1,0 +1,19 @@
+import Oven from '../src/js/oven.js';
+import Recipe from '../src/js/recipe.js';
+import SpriteManager from '../src/js/spriteManager.js';
+import { BUILDING_TYPES } from '../src/js/constants.js';
+
+jest.mock('../src/js/recipe.js');
+
+describe('Oven', () => {
+    let oven;
+
+    beforeEach(() => {
+        oven = new Oven(0, 0, new SpriteManager());
+    });
+
+    test('should initialize with bread recipe', () => {
+        expect(oven.type).toBe(BUILDING_TYPES.OVEN);
+        expect(oven.recipes).toEqual([expect.any(Recipe)]);
+    });
+});

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -10,6 +10,7 @@ export const BUILDING_TYPES = {
   WALL: 'wall',
   FLOOR: 'floor',
   CRAFTING_STATION: 'crafting_station',
+  OVEN: 'oven',
   FARM_PLOT: 'farm_plot',
   ANIMAL_PEN: 'animal_pen',
   BARRICADE: 'barricade',
@@ -22,6 +23,7 @@ export const BUILDING_TYPE_PROPERTIES = {
   [BUILDING_TYPES.WALL]: { passable: false },
   [BUILDING_TYPES.FLOOR]: { passable: true },
   [BUILDING_TYPES.CRAFTING_STATION]: { passable: true },
+  [BUILDING_TYPES.OVEN]: { passable: true },
   [BUILDING_TYPES.FARM_PLOT]: { passable: true },
   [BUILDING_TYPES.ANIMAL_PEN]: { passable: true },
   [BUILDING_TYPES.BARRICADE]: { passable: true },
@@ -40,6 +42,7 @@ export const RESOURCE_TYPES = {
   BERRIES: 'berries',
   MUSHROOMS: 'mushrooms',
   MEAT: 'meat',
+  BREAD: 'bread',
   BANDAGE: 'bandage',
   PLANK: 'plank',
   BLOCK: 'block'
@@ -57,6 +60,7 @@ export const RESOURCE_CATEGORIES = {
   [RESOURCE_TYPES.BERRIES]: ['food'],
   [RESOURCE_TYPES.MUSHROOMS]: ['food'],
   [RESOURCE_TYPES.MEAT]: ['food'],
+  [RESOURCE_TYPES.BREAD]: ['food'],
   [RESOURCE_TYPES.BANDAGE]: ['medical'],
   [RESOURCE_TYPES.PLANK]: ['material'],
   [RESOURCE_TYPES.BLOCK]: ['material']

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -10,6 +10,7 @@ import Settler from './settler.js';
 import TaskManager from './taskManager.js';
 import Building from './building.js';
 import CraftingStation from './craftingStation.js';
+import Oven from './oven.js';
 import Task from './task.js';
 import FarmPlot from './farmPlot.js';
 import AnimalPen from './animalPen.js';
@@ -97,6 +98,8 @@ export default class Game {
                 [BUILDING_TYPES.FARM_PLOT, 'src/assets/farmPlot.png'],
                 [RESOURCE_TYPES.BANDAGE, 'src/assets/bandage.png'],
                 [BUILDING_TYPES.CRAFTING_STATION, 'src/assets/crafting_station.png'],
+                [BUILDING_TYPES.OVEN, 'src/assets/oven.png'],
+                [RESOURCE_TYPES.BREAD, 'src/assets/bread.png'],
                 [BUILDING_TYPES.TABLE, 'src/assets/table.png'],
                 [BUILDING_TYPES.BED, 'src/assets/bed.png'],
                 ['wheat_1', 'src/assets/wheat_1.png'],
@@ -227,7 +230,10 @@ export default class Game {
                     }
                 }
             }
-            if (building.type === BUILDING_TYPES.CRAFTING_STATION) {
+            if (
+                building.type === BUILDING_TYPES.CRAFTING_STATION ||
+                building.type === BUILDING_TYPES.OVEN
+            ) {
                 const station = building;
                 if (station.buildProgress === 100 && station.autoCraft && station.desiredRecipe) {
                     const hasTask = this.taskManager.tasks.some(
@@ -728,6 +734,8 @@ export default class Game {
                 newBuilding = new Furniture(BUILDING_TYPES.BED, tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 50, this.spriteManager);
             } else if (this.selectedBuilding === BUILDING_TYPES.TABLE) {
                 newBuilding = new Furniture(BUILDING_TYPES.TABLE, tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 75, this.spriteManager);
+            } else if (this.selectedBuilding === BUILDING_TYPES.OVEN) {
+                newBuilding = new Oven(tileX, tileY, this.spriteManager);
             } else if (this.selectedBuilding === BUILDING_TYPES.BARRICADE) {
                 newBuilding = new Building(BUILDING_TYPES.BARRICADE, tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 0); // Barricade is a simple building
             } else if (this.selectedBuilding === BUILDING_TYPES.WALL) {
@@ -782,7 +790,10 @@ export default class Game {
                 // Check if a building was clicked
                 const clickedBuilding = this.map.getBuildingAt(tileX, tileY);
                 if (clickedBuilding) {
-                    if (clickedBuilding.type === BUILDING_TYPES.CRAFTING_STATION) {
+                    if (
+                        clickedBuilding.type === BUILDING_TYPES.CRAFTING_STATION ||
+                        clickedBuilding.type === BUILDING_TYPES.OVEN
+                    ) {
                         const craftingStation = clickedBuilding;
                         this.ui.showCraftingStationMenu(craftingStation, event.clientX, event.clientY);
                     } else if (clickedBuilding.type === BUILDING_TYPES.FARM_PLOT) {

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -1,6 +1,7 @@
 import ResourcePile from './resourcePile.js';
 import Building from './building.js';
 import CraftingStation from './craftingStation.js';
+import Oven from './oven.js';
 import FarmPlot from './farmPlot.js';
 import AnimalPen from './animalPen.js';
 import Furniture from './furniture.js';
@@ -267,6 +268,8 @@ export default class Map {
             let building;
             if (buildingData.type === BUILDING_TYPES.CRAFTING_STATION) {
                 building = new CraftingStation(buildingData.x, buildingData.y, this.spriteManager);
+            } else if (buildingData.type === BUILDING_TYPES.OVEN) {
+                building = new Oven(buildingData.x, buildingData.y, this.spriteManager);
             } else if (buildingData.type === BUILDING_TYPES.FARM_PLOT) {
                 building = new FarmPlot(buildingData.x, buildingData.y, this.spriteManager);
             } else if (buildingData.type === BUILDING_TYPES.ANIMAL_PEN) {

--- a/src/js/oven.js
+++ b/src/js/oven.js
@@ -1,0 +1,29 @@
+import CraftingStation from './craftingStation.js';
+import Recipe from './recipe.js';
+import { RESOURCE_TYPES, BUILDING_TYPES, BUILDING_TYPE_PROPERTIES } from './constants.js';
+
+export default class Oven extends CraftingStation {
+    constructor(x, y, spriteManager = null) {
+        super(x, y, spriteManager);
+        this.type = BUILDING_TYPES.OVEN;
+        this.passable = BUILDING_TYPE_PROPERTIES[this.type]?.passable ?? true;
+        this.stationSprite = spriteManager ? spriteManager.getSprite(BUILDING_TYPES.OVEN) : null;
+        this.recipes = [];
+        this.autoCraft = false;
+        this.desiredRecipe = null;
+        this.addRecipe(
+            new Recipe(
+                'bread',
+                [{ resourceType: RESOURCE_TYPES.WHEAT, quantity: 1 }],
+                [
+                    {
+                        resourceType: RESOURCE_TYPES.BREAD,
+                        quantity: 1,
+                        quality: 1,
+                    },
+                ],
+                3,
+            ),
+        );
+    }
+}

--- a/src/js/resourcePile.js
+++ b/src/js/resourcePile.js
@@ -33,6 +33,7 @@ export default class ResourcePile extends Resource {
         const meatSprite = this.spriteManager.getSprite(RESOURCE_TYPES.MEAT);
         const mushroomsSprite = this.spriteManager.getSprite(RESOURCE_TYPES.MUSHROOMS);
         const bandageSprite = this.spriteManager.getSprite(RESOURCE_TYPES.BANDAGE);
+        const breadSprite = this.spriteManager.getSprite(RESOURCE_TYPES.BREAD);
         const dirtPileSprite = this.spriteManager.getSprite('dirt_pile');
         const wheatPileSprite = this.spriteManager.getSprite('wheat_pile');
         const cottonPileSprite = this.spriteManager.getSprite('cotton_pile');
@@ -49,6 +50,8 @@ export default class ResourcePile extends Resource {
             ctx.drawImage(mushroomsSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
         } else if (this.type === RESOURCE_TYPES.BANDAGE && bandageSprite) {
             ctx.drawImage(bandageSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
+        } else if (this.type === RESOURCE_TYPES.BREAD && breadSprite) {
+            ctx.drawImage(breadSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
         } else if (this.type === RESOURCE_TYPES.DIRT && dirtPileSprite) {
             ctx.drawImage(dirtPileSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
         } else if (this.type === RESOURCE_TYPES.WHEAT && wheatPileSprite) {

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -400,6 +400,7 @@ export default class UI {
                 createButton('Build Wall', BUILDING_TYPES.WALL, false, 'Builds a defensive wall.');
                 createButton('Build Floor', BUILDING_TYPES.FLOOR, false, 'Lays down a floor tile.');
                 createButton('Build Crafting Station', BUILDING_TYPES.CRAFTING_STATION, false, 'Allows settlers to craft items.');
+                createButton('Build Oven', BUILDING_TYPES.OVEN, false, 'Bakes bread from wheat.');
                 createButton('Build Farm Plot', BUILDING_TYPES.FARM_PLOT, false, 'Used for growing crops.');
                 createButton('Build Animal Pen', BUILDING_TYPES.ANIMAL_PEN, false, 'Houses livestock.');
                 createButton('Build Barricade', BUILDING_TYPES.BARRICADE, false, 'A simple defensive barrier.');


### PR DESCRIPTION
## Summary
- add Oven class derived from CraftingStation
- load oven sprite and bread resource in the game
- support oven placement and autocrating logic
- add bread resource type and categories
- display bread piles
- allow building an oven from the UI
- load/save ovens in map data
- test oven creation

## Testing
- `npm test` *(fails: UI.test.js)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68873a068b3c8323b812e4d5e0e2dc22