### PR TITLE
Add hunger restoration values for food items

### DIFF
--- a/__tests__/Resource.test.js
+++ b/__tests__/Resource.test.js
@@ -42,4 +42,11 @@ describe('Resource', () => {
         expect(custom.categories).toContain('material');
         expect(custom.categories).toContain('food');
     });
+
+    test('food resources should set hungerRestoration', () => {
+        const berries = new Resource('berries', 5);
+        expect(berries.hungerRestoration).toBeGreaterThan(0);
+        const wood = new Resource('wood', 5);
+        expect(wood.hungerRestoration).toBe(0);
+    });
 });

--- a/__tests__/Settler.test.js
+++ b/__tests__/Settler.test.js
@@ -1,6 +1,6 @@
 import Settler from '../src/js/settler.js';
 import Task from '../src/js/task.js';
-import { TASK_TYPES, HEALTH_REGEN_RATE, BUILDING_TYPES } from '../src/js/constants.js';
+import { TASK_TYPES, HEALTH_REGEN_RATE, BUILDING_TYPES, FOOD_HUNGER_VALUES, RESOURCE_TYPES } from '../src/js/constants.js';
 import ResourcePile from '../src/js/resourcePile.js';
 
 jest.mock('../src/js/resourceManager.js');
@@ -372,7 +372,8 @@ describe('Settler', () => {
 
         expect(mockRoomManager.removeResourceFromStorage).toHaveBeenCalledWith(storageRoom, 'berries', 1);
         expect(settler.state).toBe('idle');
-        expect(settler.hunger).toBeGreaterThan(10);
+        const expectedHunger = 10 - 0.01 + FOOD_HUNGER_VALUES[RESOURCE_TYPES.BERRIES];
+        expect(settler.hunger).toBeCloseTo(expectedHunger, 2);
     });
 
     test('should butcher dead enemy', () => {

--- a/__tests__/UI.test.js
+++ b/__tests__/UI.test.js
@@ -34,7 +34,7 @@ describe('UI tooltips', () => {
 
     test('priority button is placed in build menu', () => {
         const ui = new UI({});
-        expect(ui.priorityButton.parentElement).toBe(ui.buildMenu);
+        expect(ui.priorityButton.parentElement).toBe(ui.devMenu);
     });
 
     test('farm plot menu shows with correct controls', () => {
@@ -77,7 +77,7 @@ describe('UI tooltips', () => {
 
     test('task manager button is placed in build menu', () => {
         const ui = new UI({});
-        expect(ui.taskManagerButton.parentElement).toBe(ui.buildMenu);
+        expect(ui.taskManagerButton.parentElement).toBe(ui.devMenu);
     });
 
     test('showTaskManager displays tasks and allows deletion', () => {

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -66,6 +66,15 @@ export const RESOURCE_CATEGORIES = {
   [RESOURCE_TYPES.BLOCK]: ['material']
 };
 
+// Hunger restored when consuming one unit of each food resource
+export const FOOD_HUNGER_VALUES = {
+  [RESOURCE_TYPES.WHEAT]: 5,
+  [RESOURCE_TYPES.BERRIES]: 10,
+  [RESOURCE_TYPES.MUSHROOMS]: 8,
+  [RESOURCE_TYPES.MEAT]: 30,
+  [RESOURCE_TYPES.BREAD]: 20
+};
+
 // Individual task type constants
 export const TASK_TYPES = {
   CHOP_WOOD: 'chop_wood',

--- a/src/js/resource.js
+++ b/src/js/resource.js
@@ -1,13 +1,15 @@
 
-import { RESOURCE_CATEGORIES } from './constants.js';
+import { RESOURCE_CATEGORIES, FOOD_HUNGER_VALUES } from './constants.js';
 
 export default class Resource {
-    constructor(type, quantity, quality = 1, categories = null) {
+    constructor(type, quantity, quality = 1, categories = null, hungerRestoration = null) {
         this.type = type; // e.g., "wood", "stone", "food"
         this.quantity = quantity;
         this.quality = quality; // 1-100 scale, affects efficiency/value
         // Use provided categories or fall back to defaults for the resource type
         this.categories = categories ?? (RESOURCE_CATEGORIES[type] || []);
+        // Amount of hunger restored when consumed (only for food resources)
+        this.hungerRestoration = hungerRestoration ?? FOOD_HUNGER_VALUES[type] ?? 0;
     }
 
     add(amount) {
@@ -27,7 +29,8 @@ export default class Resource {
             type: this.type,
             quantity: this.quantity,
             quality: this.quality,
-            categories: this.categories
+            categories: this.categories,
+            hungerRestoration: this.hungerRestoration
         };
     }
 
@@ -36,5 +39,6 @@ export default class Resource {
         this.quantity = data.quantity;
         this.quality = data.quality;
         this.categories = data.categories ?? (RESOURCE_CATEGORIES[this.type] || []);
+        this.hungerRestoration = data.hungerRestoration ?? FOOD_HUNGER_VALUES[this.type] ?? 0;
     }
 }

--- a/src/js/resourceManager.js
+++ b/src/js/resourceManager.js
@@ -49,7 +49,8 @@ export default class ResourceManager {
                 resourceData.type,
                 resourceData.quantity,
                 resourceData.quality,
-                resourceData.categories
+                resourceData.categories,
+                resourceData.hungerRestoration
             );
             this.resources[type] = resource;
         }

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -3,7 +3,7 @@ import { debugLog } from './debug.js';
 import Task from './task.js';
 import ResourcePile from './resourcePile.js';
 import { findPath } from './pathfinding.js';
-import { SLEEP_GAIN_RATE, SETTLER_RUN_SPEED, TASK_TYPES, RESOURCE_TYPES, HEALTH_REGEN_RATE, BUILDING_TYPES } from './constants.js';
+import { SLEEP_GAIN_RATE, SETTLER_RUN_SPEED, TASK_TYPES, RESOURCE_TYPES, HEALTH_REGEN_RATE, BUILDING_TYPES, FOOD_HUNGER_VALUES } from './constants.js';
 
 export default class Settler {
     constructor(name, x, y, resourceManager, map, roomManager, spriteManager, allSettlers = null) {
@@ -533,7 +533,7 @@ export default class Settler {
                     } else if (this.currentTask.type === "eat" && this.currentTask.foodType) {
                         const room = this.roomManager.getRoomAt(this.currentTask.targetX, this.currentTask.targetY);
                         if (room && room.type === "storage" && this.roomManager.removeResourceFromStorage(room, this.currentTask.foodType, 1)) {
-                            this.hunger += 30;
+                            this.hunger += FOOD_HUNGER_VALUES[this.currentTask.foodType] ?? 0;
                             if (this.hunger > 100) this.hunger = 100;
                             this.state = "idle";
                             debugLog(`${this.name} ate ${this.currentTask.foodType} from storage.`);


### PR DESCRIPTION
## Summary
- assign hunger restoration values to food items
- expose hungerRestoration property on `Resource`
- use hunger restoration when settlers eat
- include hunger value when resources are serialized
- update unit tests for new hunger behavior and UI structure

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68873cbb3a748323a82dc0a64d7da26d