### PR TITLE
Add baking skill and task for oven crafting

### DIFF
--- a/__tests__/Game.test.js
+++ b/__tests__/Game.test.js
@@ -301,6 +301,14 @@ describe('Game', () => {
         expect(haulTask.priority).toBeGreaterThan(craftTask.priority);
     });
 
+    test('addCraftTask uses baking task type for ovens', () => {
+        const station = { x: 2, y: 3, type: BUILDING_TYPES.OVEN, getResourceQuantity: jest.fn().mockReturnValue(0), buildProgress: 100 };
+        const recipe = { inputs: [], outputs: [], time: 1, name: 'bread' };
+        game.addCraftTask(station, recipe);
+        const craftTask = game.taskManager.addTask.mock.calls.find(c => c[0].type !== TASK_TYPES.HAUL)[0];
+        expect(craftTask.type).toBe(TASK_TYPES.BAKING);
+    });
+
     test('addCraftTask does not queue tasks if station not built', () => {
         const station = { x: 2, y: 3, getResourceQuantity: jest.fn(), buildProgress: 50 };
         const recipe = { inputs: [], outputs: [], time: 1, name: 'bandage' };

--- a/__tests__/Settler.test.js
+++ b/__tests__/Settler.test.js
@@ -59,6 +59,7 @@ describe('Settler', () => {
             mining: 1,
             building: 1,
             crafting: 1,
+            baking: 1,
             combat: 1,
             medical: 1
         });
@@ -180,6 +181,13 @@ describe('Settler', () => {
         expect(settler.calculateOutputQuality(-1)).toBe(0);
         settler.skills.crafting = 100;
         expect(settler.calculateOutputQuality(1)).toBe(2);
+    });
+
+    test('calculateOutputQuality uses baking skill when crafting at an oven', () => {
+        const ovenBuilding = { type: BUILDING_TYPES.OVEN };
+        settler.currentTask = new Task(TASK_TYPES.CRAFT, 0, 0, null, 0, 3, ovenBuilding);
+        settler.skills.baking = 3;
+        expect(settler.calculateOutputQuality(1)).toBeCloseTo(1.2);
     });
 
     test('should produce crafted items with correct quality', () => {

--- a/__tests__/UI.test.js
+++ b/__tests__/UI.test.js
@@ -32,9 +32,9 @@ describe('UI tooltips', () => {
         expect(ui.helpOverlay.style.display).toBe('none');
     });
 
-    test('priority button is placed in build menu', () => {
+    test('priority button is placed in dev menu', () => {
         const ui = new UI({});
-        expect(ui.priorityButton.parentElement).toBe(ui.buildMenu);
+        expect(ui.priorityButton.parentElement).toBe(ui.devMenu);
     });
 
     test('farm plot menu shows with correct controls', () => {
@@ -75,9 +75,9 @@ describe('UI tooltips', () => {
         expect(ui.loadingScreen.style.display).toBe('none');
     });
 
-    test('task manager button is placed in build menu', () => {
+    test('task manager button is placed in dev menu', () => {
         const ui = new UI({});
-        expect(ui.taskManagerButton.parentElement).toBe(ui.buildMenu);
+        expect(ui.taskManagerButton.parentElement).toBe(ui.devMenu);
     });
 
     test('showTaskManager displays tasks and allows deletion', () => {

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -77,6 +77,7 @@ export const TASK_TYPES = {
   DIG_DIRT: 'dig_dirt',
   BUILD: 'build',
   CRAFT: 'craft',
+  BAKING: 'baking',
   SOW_CROP: 'sow_crop',
   HARVEST_CROP: 'harvest_crop',
   TEND_ANIMALS: 'tend_animals',

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -493,9 +493,13 @@ export default class Game {
                 );
             });
 
+            const taskType =
+                craftingStation.type === BUILDING_TYPES.OVEN
+                    ? TASK_TYPES.BAKING
+                    : TASK_TYPES.CRAFT;
             this.taskManager.addTask(
                 new Task(
-                    TASK_TYPES.CRAFT,
+                    taskType,
                     craftingStation.x,
                     craftingStation.y,
                     null,

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -37,6 +37,7 @@ export default class Settler {
             mining: 1,
             building: 1,
             crafting: 1,
+            baking: 1,
             combat: 1,
             medical: 1
         };
@@ -363,7 +364,10 @@ export default class Settler {
                                 this.path = null; // Task completed
                             }
                         }
-                    } else if (this.currentTask.type === TASK_TYPES.CRAFT && this.currentTask.recipe) {
+                    } else if (
+                        (this.currentTask.type === TASK_TYPES.CRAFT || this.currentTask.type === TASK_TYPES.BAKING) &&
+                        this.currentTask.recipe
+                    ) {
                         const recipe = this.currentTask.recipe;
                         const station = this.currentTask.building;
 
@@ -760,9 +764,17 @@ export default class Settler {
     }
 
     calculateOutputQuality(baseQuality) {
-        // Simple quality calculation: baseQuality + (craftingSkill - 1) * 0.1
-        // This means a crafting skill of 1 gives baseQuality, 2 gives baseQuality + 0.1, etc.
-        const skillBonus = (this.skills.crafting - 1) * 0.1;
+        // Determine which skill to use for quality calculation
+        let skillLevel = this.skills.crafting;
+        if (
+            this.currentTask &&
+            this.currentTask.building &&
+            this.currentTask.building.type === BUILDING_TYPES.OVEN
+        ) {
+            skillLevel = this.skills.baking;
+        }
+        // Simple quality calculation: baseQuality + (skillLevel - 1) * 0.1
+        const skillBonus = (skillLevel - 1) * 0.1;
         let finalQuality = baseQuality + skillBonus;
         // Clamp quality between 0 and 2 (example range)
         if (finalQuality < 0) finalQuality = 0;


### PR DESCRIPTION
## Summary
- add `BAKING` to task constants
- include baking in settler skills and select it when crafting at an oven
- create baking tasks for ovens
- adjust settler crafting logic to support baking
- update UI tests and add unit tests for baking

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68873d08683c832381339fcdc643d39c