### PR TITLE
Add plank recipe to crafting station

### DIFF
--- a/__tests__/CraftingStation.test.js
+++ b/__tests__/CraftingStation.test.js
@@ -17,7 +17,7 @@ describe('CraftingStation', () => {
         expect(craftingStation.type).toBe(BUILDING_TYPES.CRAFTING_STATION);
         expect(craftingStation.x).toBe(0);
         expect(craftingStation.y).toBe(0);
-        expect(craftingStation.recipes).toEqual([expect.any(Recipe)]);
+        expect(craftingStation.recipes).toEqual([expect.any(Recipe), expect.any(Recipe)]);
         expect(craftingStation.autoCraft).toBe(false);
         expect(craftingStation.desiredRecipe).toBe(null);
     });

--- a/src/js/craftingStation.js
+++ b/src/js/craftingStation.js
@@ -28,6 +28,22 @@ export default class CraftingStation extends Building {
                 3,
             ),
         );
+
+        // New recipe: Plank from wood
+        this.addRecipe(
+            new Recipe(
+                "plank",
+                [{ resourceType: RESOURCE_TYPES.WOOD, quantity: 1 }],
+                [
+                    {
+                        resourceType: RESOURCE_TYPES.PLANK,
+                        quantity: 1,
+                        quality: 1,
+                    },
+                ],
+                2,
+            ),
+        );
     }
 
     addRecipe(recipe) {

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -91,6 +91,7 @@ export default class Game {
                 ['mushroom', 'src/assets/mushroom.png'],
                 ['mushrooms', 'src/assets/mushrooms.png'],
                 [RESOURCE_TYPES.WOOD, 'src/assets/wood.png'],
+                [RESOURCE_TYPES.PLANK, 'src/assets/plank.png'],
                 ['stone_pile', 'src/assets/stone_pile.png'],
                 [RESOURCE_TYPES.BERRIES, 'src/assets/berries.png'],
                 [RESOURCE_TYPES.MEAT, 'src/assets/meat.png'],


### PR DESCRIPTION
## Summary
- enable crafting planks from wood
- load plank sprite
- adjust crafting station tests for the new default recipe

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68874d1e621483238e2b35ffb3e342ee