### PR TITLE
Add bucket crafting recipe

### DIFF
--- a/__tests__/CraftingStation.test.js
+++ b/__tests__/CraftingStation.test.js
@@ -17,7 +17,7 @@ describe('CraftingStation', () => {
         expect(craftingStation.type).toBe(BUILDING_TYPES.CRAFTING_STATION);
         expect(craftingStation.x).toBe(0);
         expect(craftingStation.y).toBe(0);
-        expect(craftingStation.recipes).toEqual([expect.any(Recipe), expect.any(Recipe)]);
+        expect(craftingStation.recipes).toEqual([expect.any(Recipe), expect.any(Recipe), expect.any(Recipe)]);
         expect(craftingStation.autoCraft).toBe(false);
         expect(craftingStation.desiredRecipe).toBe(null);
     });

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -45,6 +45,7 @@ export const RESOURCE_TYPES = {
   BREAD: 'bread',
   BANDAGE: 'bandage',
   PLANK: 'plank',
+  BUCKET: 'bucket',
   BLOCK: 'block'
 };
 
@@ -63,6 +64,7 @@ export const RESOURCE_CATEGORIES = {
   [RESOURCE_TYPES.BREAD]: ['food'],
   [RESOURCE_TYPES.BANDAGE]: ['medical'],
   [RESOURCE_TYPES.PLANK]: ['material'],
+  [RESOURCE_TYPES.BUCKET]: ['material'],
   [RESOURCE_TYPES.BLOCK]: ['material']
 };
 

--- a/src/js/craftingStation.js
+++ b/src/js/craftingStation.js
@@ -44,6 +44,22 @@ export default class CraftingStation extends Building {
                 2,
             ),
         );
+
+        // New recipe: Bucket from plank
+        this.addRecipe(
+            new Recipe(
+                "bucket",
+                [{ resourceType: RESOURCE_TYPES.PLANK, quantity: 1 }],
+                [
+                    {
+                        resourceType: RESOURCE_TYPES.BUCKET,
+                        quantity: 1,
+                        quality: 1,
+                    },
+                ],
+                2,
+            ),
+        );
     }
 
     addRecipe(recipe) {

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -92,6 +92,7 @@ export default class Game {
                 ['mushrooms', 'src/assets/mushrooms.png'],
                 [RESOURCE_TYPES.WOOD, 'src/assets/wood.png'],
                 [RESOURCE_TYPES.PLANK, 'src/assets/plank.png'],
+                [RESOURCE_TYPES.BUCKET, 'src/assets/bucket.png'],
                 ['stone_pile', 'src/assets/stone_pile.png'],
                 [RESOURCE_TYPES.BERRIES, 'src/assets/berries.png'],
                 [RESOURCE_TYPES.MEAT, 'src/assets/meat.png'],

--- a/src/js/resourcePile.js
+++ b/src/js/resourcePile.js
@@ -39,6 +39,7 @@ export default class ResourcePile extends Resource {
         const cottonPileSprite = this.spriteManager.getSprite('cotton_pile');
         const ironOrePileSprite = this.spriteManager.getSprite('iron_ore_pile');
         const plankSprite = this.spriteManager.getSprite(RESOURCE_TYPES.PLANK);
+        const bucketSprite = this.spriteManager.getSprite(RESOURCE_TYPES.BUCKET);
         if (this.type === RESOURCE_TYPES.WOOD && woodSprite) {
             ctx.drawImage(woodSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
         } else if (this.type === RESOURCE_TYPES.STONE && stonePileSprite) {
@@ -63,6 +64,8 @@ export default class ResourcePile extends Resource {
             ctx.drawImage(ironOrePileSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
         } else if (this.type === RESOURCE_TYPES.PLANK && plankSprite) {
             ctx.drawImage(plankSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
+        } else if (this.type === RESOURCE_TYPES.BUCKET && bucketSprite) {
+            ctx.drawImage(bucketSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
         }
         else {
             ctx.fillStyle = 'brown'; // Placeholder color for wood piles


### PR DESCRIPTION
## Summary
- introduce `BUCKET` resource type
- support bucket sprite/piles
- load bucket sprite in the game
- craft a bucket from a plank at the crafting station
- update crafting station tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68875744e9fc8323a8acbcecf89c1404