### PR TITLE
Update oven construction cost

### DIFF
--- a/__tests__/Oven.test.js
+++ b/__tests__/Oven.test.js
@@ -1,7 +1,7 @@
 import Oven from '../src/js/oven.js';
 import Recipe from '../src/js/recipe.js';
 import SpriteManager from '../src/js/spriteManager.js';
-import { BUILDING_TYPES } from '../src/js/constants.js';
+import { BUILDING_TYPES, RESOURCE_TYPES } from '../src/js/constants.js';
 
 jest.mock('../src/js/recipe.js');
 
@@ -15,5 +15,7 @@ describe('Oven', () => {
     test('should initialize with bread recipe', () => {
         expect(oven.type).toBe(BUILDING_TYPES.OVEN);
         expect(oven.recipes).toEqual([expect.any(Recipe)]);
+        expect(oven.material).toBe(RESOURCE_TYPES.STONE);
+        expect(oven.resourcesRequired).toBe(1);
     });
 });

--- a/src/js/oven.js
+++ b/src/js/oven.js
@@ -6,6 +6,8 @@ export default class Oven extends CraftingStation {
     constructor(x, y, spriteManager = null) {
         super(x, y, spriteManager);
         this.type = BUILDING_TYPES.OVEN;
+        this.material = RESOURCE_TYPES.STONE;
+        this.resourcesRequired = 1;
         this.passable = BUILDING_TYPE_PROPERTIES[this.type]?.passable ?? true;
         this.stationSprite = spriteManager ? spriteManager.getSprite(BUILDING_TYPES.OVEN) : null;
         this.recipes = [];


### PR DESCRIPTION
## Summary
- update oven to require stone for construction
- test that oven uses stone during initialization

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68875774fdc48323befb25ee89495bfb