### PR TITLE
Enhance task assignment priorities

### DIFF
--- a/__tests__/TaskManager.test.js
+++ b/__tests__/TaskManager.test.js
@@ -72,8 +72,8 @@ describe('TaskManager', () => {
     });
 
     test('assignTasks chooses idle settler with highest priority', () => {
-        const settlerA = { name: 'A', state: 'idle', currentTask: null, taskPriorities: { [TASK_TYPES.BUILD]: 2 } };
-        const settlerB = { name: 'B', state: 'idle', currentTask: null, taskPriorities: { [TASK_TYPES.BUILD]: 5 } };
+        const settlerA = { name: 'A', state: 'idle', currentTask: null, taskPriorities: { [TASK_TYPES.BUILD]: 2 }, skills: { building: 1 } };
+        const settlerB = { name: 'B', state: 'idle', currentTask: null, taskPriorities: { [TASK_TYPES.BUILD]: 5 }, skills: { building: 1 } };
         const buildTask = new Task(TASK_TYPES.BUILD, 1, 1);
         taskManager.addTask(buildTask);
 
@@ -83,6 +83,30 @@ describe('TaskManager', () => {
         expect(settlerA.currentTask).toBeNull();
         expect(taskManager.tasks.length).toBe(1);
         expect(buildTask.assigned).toBe('B');
+    });
+
+    test('assignTasks uses settler skill when priorities equal', () => {
+        const settlerA = { name: 'A', state: 'idle', currentTask: null, taskPriorities: { [TASK_TYPES.BUILD]: 5 }, skills: { building: 1 } };
+        const settlerB = { name: 'B', state: 'idle', currentTask: null, taskPriorities: { [TASK_TYPES.BUILD]: 5 }, skills: { building: 3 } };
+        const buildTask = new Task(TASK_TYPES.BUILD, 1, 1);
+        taskManager.addTask(buildTask);
+
+        taskManager.assignTasks([settlerA, settlerB]);
+
+        expect(settlerB.currentTask).toBe(buildTask);
+        expect(settlerA.currentTask).toBeNull();
+    });
+
+    test('assignTasks uses proximity when priority and skill equal', () => {
+        const settlerA = { name: 'A', state: 'idle', currentTask: null, x: 5, y: 5, taskPriorities: { [TASK_TYPES.BUILD]: 5 }, skills: { building: 1 } };
+        const settlerB = { name: 'B', state: 'idle', currentTask: null, x: 1, y: 1, taskPriorities: { [TASK_TYPES.BUILD]: 5 }, skills: { building: 1 } };
+        const buildTask = new Task(TASK_TYPES.BUILD, 0, 0);
+        taskManager.addTask(buildTask);
+
+        taskManager.assignTasks([settlerA, settlerB]);
+
+        expect(settlerB.currentTask).toBe(buildTask);
+        expect(settlerA.currentTask).toBeNull();
     });
 
     test('removeTask deletes a task', () => {


### PR DESCRIPTION
## Summary
- map task types to a corresponding settler skill
- assign tasks based on priority, skill level, then proximity
- test skill and distance based assignment

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688760bff0088323b1329724ce7e7b40