### PR TITLE
Allow delivering building resources from adjacent tiles

### DIFF
--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -112,6 +112,19 @@ export default class Settler {
         this.carrying = null;
     }
 
+    isAdjacentToBuilding(building) {
+        const left = building.x;
+        const right = building.x + (building.width || 1) - 1;
+        const top = building.y;
+        const bottom = building.y + (building.height || 1) - 1;
+        const sx = Math.floor(this.x);
+        const sy = Math.floor(this.y);
+        const dx = Math.max(left - sx, 0, sx - right);
+        const dy = Math.max(top - sy, 0, sy - bottom);
+        const distance = Math.max(dx, dy);
+        return distance <= 1;
+    }
+
     setTargetEnemy(enemy) {
         this.targetEnemy = enemy;
         if (enemy) {
@@ -370,7 +383,11 @@ export default class Settler {
                         const amountToConsume = consumptionRate * (deltaTime / 1000);
     
                         if (building.resourcesDelivered < building.resourcesRequired) {
-                            if (this.carrying && this.carrying.type === material) {
+                            if (
+                                this.carrying &&
+                                this.carrying.type === material &&
+                                this.isAdjacentToBuilding(building)
+                            ) {
                                 const needed = building.resourcesRequired - building.resourcesDelivered;
                                 const amountToDrop = Math.min(needed, this.carrying.quantity);
                                 building.addToInventory(material, amountToDrop);
@@ -621,7 +638,7 @@ export default class Settler {
                                     this.path = null;
                                 }
                             }
-                        } else if (this.carrying && this.x === building.x && this.y === building.y) {
+                        } else if (this.carrying && this.isAdjacentToBuilding(building)) {
                             building.addToInventory(this.carrying.type, this.carrying.quantity);
                             const deliveredType = this.currentTask.resourceType;
                             this.carrying = null;


### PR DESCRIPTION
## Summary
- add `isAdjacentToBuilding` helper in Settler
- allow builders and haulers to deliver materials when adjacent to a building
- require adjacency when builders drop resources

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68876394d8e48323a74210593a3c8728