### PR TITLE
Fix pathfinding water traversal bug

### DIFF
--- a/__tests__/Settler.test.js
+++ b/__tests__/Settler.test.js
@@ -25,7 +25,11 @@ describe('Settler', () => {
             resourcePiles: [],
             addResourcePile: jest.fn(function(pile) { this.resourcePiles.push(pile); }),
             tileSize: 1,
-            buildings: []
+            buildings: [],
+            width: 20,
+            height: 20,
+            getTile: jest.fn(() => 0),
+            getBuildingAt: jest.fn(() => null)
         };
         mockRoomManager = {
             rooms: [],
@@ -145,8 +149,7 @@ describe('Settler', () => {
         settler.y = 0;
         settler.updateNeeds(1000); // Simulate 1 second
         // Expect settler to have moved towards (10,10)
-        expect(settler.x).toBeGreaterThan(0);
-        expect(settler.y).toBeGreaterThan(0);
+        expect(settler.x + settler.y).toBeGreaterThan(0);
         expect(settler.x).toBeLessThan(10);
         expect(settler.y).toBeLessThan(10);
     });

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -349,9 +349,19 @@ export default class Settler {
                 if (Math.floor(this.x) === this.currentTask.targetX && Math.floor(this.y) === this.currentTask.targetY) {
                     this.path = [];
                 } else {
-                    this.path = findPath({ x: Math.floor(this.x), y: Math.floor(this.y) }, { x: this.currentTask.targetX, y: this.currentTask.targetY }, this.map);
+                    this.path = findPath(
+                        { x: Math.floor(this.x), y: Math.floor(this.y) },
+                        { x: this.currentTask.targetX, y: this.currentTask.targetY },
+                        this.map,
+                    );
                     if (!this.path) {
-                        this.path = [{ x: this.currentTask.targetX, y: this.currentTask.targetY }];
+                        debugLog(
+                            `${this.name} cannot reach ${this.currentTask.targetX},${this.currentTask.targetY}. Task cancelled.`,
+                        );
+                        this.currentTask = null;
+                        this.path = null;
+                        this.state = 'idle';
+                        return;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- prevent settlers from walking through water when no path exists
- ensure tests provide map dimensions for pathfinding
- update movement test to check for any progress

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887668a64d08323bbbb4fd30662ecbf