### PR TITLE
restrict water building

### DIFF
--- a/__tests__/Game.test.js
+++ b/__tests__/Game.test.js
@@ -186,6 +186,28 @@ describe('Game', () => {
         expect(game.map.addBuilding).not.toHaveBeenCalled();
     });
 
+    test('handleClick should not place non-floor building on water tile', () => {
+        const expectedTileX = Math.floor(((100 - mockCtx.canvas.width / 2) / game.camera.zoom + game.camera.x) / game.map.tileSize);
+        const expectedTileY = Math.floor(((100 - mockCtx.canvas.height / 2) / game.camera.zoom + game.camera.y) / game.map.tileSize);
+        game.map.getTile.mockReturnValue(8); // Water tile
+        game.map.findAdjacentFreeTile = jest.fn().mockReturnValue({ x: expectedTileX + 1, y: expectedTileY });
+        game.toggleBuildMode(BUILDING_TYPES.WALL);
+        game.handleClick({ clientX: 100, clientY: 100, target: { closest: () => null } });
+
+        expect(game.map.addBuilding).not.toHaveBeenCalled();
+    });
+
+    test('handleClick should allow floor building on water tile', () => {
+        const expectedTileX = Math.floor(((100 - mockCtx.canvas.width / 2) / game.camera.zoom + game.camera.x) / game.map.tileSize);
+        const expectedTileY = Math.floor(((100 - mockCtx.canvas.height / 2) / game.camera.zoom + game.camera.y) / game.map.tileSize);
+        game.map.getTile.mockReturnValue(8); // Water tile
+        game.map.findAdjacentFreeTile = jest.fn().mockReturnValue({ x: expectedTileX + 1, y: expectedTileY });
+        game.toggleBuildMode(BUILDING_TYPES.FLOOR);
+        game.handleClick({ clientX: 100, clientY: 100, target: { closest: () => null } });
+
+        expect(game.map.addBuilding).toHaveBeenCalledTimes(1);
+    });
+
     test('handleClick on farm plot shows menu', () => {
         const tileX = Math.floor(((100 - mockCtx.canvas.width / 2) / game.camera.zoom + game.camera.x) / game.map.tileSize);
         const tileY = Math.floor(((100 - mockCtx.canvas.height / 2) / game.camera.zoom + game.camera.y) / game.map.tileSize);

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -728,6 +728,10 @@ export default class Game {
         }
 
         if (this.buildMode && this.selectedBuilding) {
+            if (clickedTile === 8 && this.selectedBuilding !== BUILDING_TYPES.FLOOR) {
+                debugLog('Cannot build here. Only floors can be built on water tiles.');
+                return;
+            }
             // Place the selected building
             let newBuilding;
             if (this.selectedBuilding === BUILDING_TYPES.CRAFTING_STATION) {


### PR DESCRIPTION
## Summary
- restrict building placement on water tiles to floor only
- test non-floor building on water tile is blocked
- test floor building on water tile is allowed

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68876900f1a48323a940e2a6ed2c40d3