### PR TITLE
Fix floor building passability on water

### DIFF
--- a/__tests__/Map.test.js
+++ b/__tests__/Map.test.js
@@ -1,5 +1,7 @@
 import Map from '../src/js/map.js';
 import ResourcePile from '../src/js/resourcePile.js';
+import Building from '../src/js/building.js';
+import { BUILDING_TYPES } from '../src/js/constants.js';
 
 describe('Map resource piles', () => {
     test('should not allow multiple piles on same tile', () => {
@@ -54,5 +56,21 @@ describe('Map resource piles', () => {
             );
         });
         expect(hasCluster).toBe(true);
+    });
+});
+
+describe('findAdjacentFreeTile', () => {
+    test('returns passable floor tile on water', () => {
+        const map = new Map(3, 3, 32, { getSprite: jest.fn() });
+        map.tiles = [
+            [0, 0, 0],
+            [0, 8, 8],
+            [0, 0, 0],
+        ];
+        const floor = new Building(BUILDING_TYPES.FLOOR, 1, 1, 1, 1, 'wood', 100);
+        map.addBuilding(floor);
+
+        const pos = map.findAdjacentFreeTile(2, 1);
+        expect(pos).toEqual({ x: 1, y: 1 });
     });
 });

--- a/__tests__/Pathfinding.test.js
+++ b/__tests__/Pathfinding.test.js
@@ -46,4 +46,19 @@ describe('findPath with buildings', () => {
         expect(path).not.toBeNull();
         expect(path.some(p => p.x === 1 && p.y === 1)).toBe(false);
     });
+
+    test('floor on water becomes passable', () => {
+        const tiles = [
+            [0, 0, 0],
+            [0, 8, 0],
+            [0, 0, 0],
+        ];
+        const buildings = [{ x: 1, y: 1, type: BUILDING_TYPES.FLOOR }];
+        const map = new MockMap(tiles, buildings);
+        const path = findPath({ x: 0, y: 1 }, { x: 2, y: 1 }, map);
+        expect(path).toEqual([
+            { x: 1, y: 1 },
+            { x: 2, y: 1 },
+        ]);
+    });
 });

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -154,8 +154,9 @@ export default class Map {
                 const buildingPassable = b
                     ? BUILDING_TYPE_PROPERTIES[b.type]?.passable !== false
                     : true;
+
                 if (tile !== 8 || buildingPassable) {
-                    if (!b) {
+                    if (!b || buildingPassable) {
                         if (fromX !== null && fromY !== null) {
                             const dist = (fromX - nx) ** 2 + (fromY - ny) ** 2;
                             if (dist < bestDist) {

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -5,7 +5,7 @@ import Oven from './oven.js';
 import FarmPlot from './farmPlot.js';
 import AnimalPen from './animalPen.js';
 import Furniture from './furniture.js';
-import { BUILDING_TYPES } from './constants.js';
+import { BUILDING_TYPES, BUILDING_TYPE_PROPERTIES } from './constants.js';
 
 export default class Map {
     constructor(width, height, tileSize, spriteManager) {
@@ -148,22 +148,24 @@ export default class Map {
         for (const { dx, dy } of directions) {
             const nx = x + dx;
             const ny = y + dy;
-            if (
-                nx >= 0 &&
-                nx < this.width &&
-                ny >= 0 &&
-                ny < this.height &&
-                this.getTile(nx, ny) !== 8 &&
-                !this.getBuildingAt(nx, ny)
-            ) {
-                if (fromX !== null && fromY !== null) {
-                    const dist = (fromX - nx) ** 2 + (fromY - ny) ** 2;
-                    if (dist < bestDist) {
-                        bestDist = dist;
-                        best = { x: nx, y: ny };
+            if (nx >= 0 && nx < this.width && ny >= 0 && ny < this.height) {
+                const tile = this.getTile(nx, ny);
+                const b = this.getBuildingAt(nx, ny);
+                const buildingPassable = b
+                    ? BUILDING_TYPE_PROPERTIES[b.type]?.passable !== false
+                    : true;
+                if (tile !== 8 || buildingPassable) {
+                    if (!b) {
+                        if (fromX !== null && fromY !== null) {
+                            const dist = (fromX - nx) ** 2 + (fromY - ny) ** 2;
+                            if (dist < bestDist) {
+                                bestDist = dist;
+                                best = { x: nx, y: ny };
+                            }
+                        } else {
+                            return { x: nx, y: ny };
+                        }
                     }
-                } else {
-                    return { x: nx, y: ny };
                 }
             }
         }

--- a/src/js/pathfinding.js
+++ b/src/js/pathfinding.js
@@ -65,30 +65,24 @@ function getNeighbors(node, map) {
 
     const currentTile = map.getTile ? map.getTile(x, y) : 0;
     const currentBuilding = map.getBuildingAt ? map.getBuildingAt(x, y) : null;
+    const currentBuildingPassable = currentBuilding
+        ? BUILDING_TYPE_PROPERTIES[currentBuilding.type]?.passable !== false
+        : false;
     const isUnpassable =
-        currentTile === 8 ||
-        (currentBuilding &&
-            BUILDING_TYPE_PROPERTIES[currentBuilding.type] &&
-            BUILDING_TYPE_PROPERTIES[currentBuilding.type].passable === false);
+        (currentTile === 8 && !currentBuildingPassable) ||
+        (currentBuilding && !currentBuildingPassable);
 
     const checkAndAdd = (nx, ny) => {
-        if (
-            nx >= 0 &&
-            nx < map.width &&
-            ny >= 0 &&
-            ny < map.height &&
-            (map.getTile ? map.getTile(nx, ny) : 0) !== 8
-        ) {
+        if (nx >= 0 && nx < map.width && ny >= 0 && ny < map.height) {
+            const tile = map.getTile ? map.getTile(nx, ny) : 0;
             const b = map.getBuildingAt ? map.getBuildingAt(nx, ny) : null;
-            if (
-                !b ||
-                !(
-                    BUILDING_TYPE_PROPERTIES[b.type] &&
-                    BUILDING_TYPE_PROPERTIES[b.type].passable === false
-                )
-            ) {
-                neighbors.push({ x: nx, y: ny });
-            }
+            const buildingPassable = b
+                ? BUILDING_TYPE_PROPERTIES[b.type]?.passable !== false
+                : true;
+
+            if (tile === 8 && (!b || !buildingPassable)) return;
+            if (b && !buildingPassable) return;
+            neighbors.push({ x: nx, y: ny });
         }
     };
 


### PR DESCRIPTION
## Summary
- allow floors to make water tiles passable in pathfinding
- support water tiles with floors when looking for adjacent free tiles
- test floor passability on water in the pathfinder

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68876a6d1e3883238907388cd0567e16