### PR TITLE
Allow building on floors over water

### DIFF
--- a/__tests__/Game.test.js
+++ b/__tests__/Game.test.js
@@ -208,6 +208,18 @@ describe('Game', () => {
         expect(game.map.addBuilding).toHaveBeenCalledTimes(1);
     });
 
+    test('handleClick should allow building on floor over water tile', () => {
+        const expectedTileX = Math.floor(((100 - mockCtx.canvas.width / 2) / game.camera.zoom + game.camera.x) / game.map.tileSize);
+        const expectedTileY = Math.floor(((100 - mockCtx.canvas.height / 2) / game.camera.zoom + game.camera.y) / game.map.tileSize);
+        game.map.getTile.mockReturnValue(8); // Water tile
+        game.map.getBuildingAt.mockReturnValue({ type: BUILDING_TYPES.FLOOR });
+        game.map.findAdjacentFreeTile = jest.fn().mockReturnValue({ x: expectedTileX + 1, y: expectedTileY });
+        game.toggleBuildMode(BUILDING_TYPES.WALL);
+        game.handleClick({ clientX: 100, clientY: 100, target: { closest: () => null } });
+
+        expect(game.map.addBuilding).toHaveBeenCalledTimes(1);
+    });
+
     test('handleClick on farm plot shows menu', () => {
         const tileX = Math.floor(((100 - mockCtx.canvas.width / 2) / game.camera.zoom + game.camera.x) / game.map.tileSize);
         const tileY = Math.floor(((100 - mockCtx.canvas.height / 2) / game.camera.zoom + game.camera.y) / game.map.tileSize);

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -728,7 +728,12 @@ export default class Game {
         }
 
         if (this.buildMode && this.selectedBuilding) {
-            if (clickedTile === 8 && this.selectedBuilding !== BUILDING_TYPES.FLOOR) {
+            const existingBuilding = this.map.getBuildingAt(tileX, tileY);
+            if (
+                clickedTile === 8 &&
+                this.selectedBuilding !== BUILDING_TYPES.FLOOR &&
+                (!existingBuilding || existingBuilding.type !== BUILDING_TYPES.FLOOR)
+            ) {
                 debugLog('Cannot build here. Only floors can be built on water tiles.');
                 return;
             }


### PR DESCRIPTION
## Summary
- allow buildings other than floors to be placed on top of floor tiles even if the underlying tile is water
- test building placement on water when a floor already exists

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6887807314ac8323a1e95a9f06e9c80f