### PR TITLE
Fix building selection when stacked

### DIFF
--- a/src/js/map.js
+++ b/src/js/map.js
@@ -123,7 +123,20 @@ export default class Map {
     }
 
     getBuildingAt(x, y) {
-        return this.buildings.find(building => building.x === x && building.y === y);
+        const buildingsAtTile = this.buildings.filter(
+            building => building.x === x && building.y === y,
+        );
+        if (buildingsAtTile.length === 0) {
+            return undefined;
+        }
+        // Prefer non-floor buildings when multiple occupy the same tile
+        for (let i = buildingsAtTile.length - 1; i >= 0; i--) {
+            if (buildingsAtTile[i].type !== BUILDING_TYPES.FLOOR) {
+                return buildingsAtTile[i];
+            }
+        }
+        // If only floors exist, return the last one
+        return buildingsAtTile[buildingsAtTile.length - 1];
     }
 
     removeBuilding(buildingToRemove) {


### PR DESCRIPTION
## Summary
- ensure the topmost building is selected when multiple buildings occupy a tile

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6887856f97f88323a401a7674aea2728