### PR TITLE
Add Well building and water bucket crafting

### DIFF
--- a/__tests__/Game.test.js
+++ b/__tests__/Game.test.js
@@ -16,8 +16,18 @@ jest.mock('../src/js/resourceManager.js');
 jest.mock('../src/js/settler.js');
 jest.mock('../src/js/taskManager.js');
 jest.mock('../src/js/building.js', () => {
-    return jest.fn().mockImplementation((type, x, y, width, height, material, buildProgress, resourcesRequired = 1) => {
-        return { type, x, y, width, height, material, buildProgress, resourcesRequired };
+    return jest.fn().mockImplementation((type, x, y, width, height, material, buildProgress, resourcesRequired = 1, constructionMaterials = null) => {
+        return {
+            type,
+            x,
+            y,
+            width,
+            height,
+            material,
+            buildProgress,
+            resourcesRequired,
+            constructionMaterials: constructionMaterials || { [material]: resourcesRequired },
+        };
     });
 });
 jest.mock('../src/js/task.js', () => {

--- a/__tests__/Game.test.js
+++ b/__tests__/Game.test.js
@@ -30,6 +30,20 @@ jest.mock('../src/js/building.js', () => {
         };
     });
 });
+jest.mock('../src/js/well.js', () => {
+    const { BUILDING_TYPES } = require('../src/js/constants.js');
+    return jest.fn().mockImplementation((x, y) => ({
+        type: BUILDING_TYPES.WELL,
+        x,
+        y,
+        width: 1,
+        height: 1,
+        material: 'plank',
+        buildProgress: 0,
+        constructionMaterials: { plank: 1, stone: 1, bucket: 1 },
+        resourcesRequired: 3,
+    }));
+});
 jest.mock('../src/js/task.js', () => {
     return jest.fn().mockImplementation((type, targetX, targetY, resourceType, quantity, priority, building, recipe, cropType, targetLocation, carrying, targetSettler, targetEnemy) => {
         return {
@@ -216,6 +230,31 @@ describe('Game', () => {
         game.handleClick({ clientX: 100, clientY: 100, target: { closest: () => null } });
 
         expect(game.map.addBuilding).toHaveBeenCalledTimes(1);
+    });
+
+    test('handleClick should allow well building on water tile', () => {
+        const expectedTileX = Math.floor(
+            ((100 - mockCtx.canvas.width / 2) / game.camera.zoom + game.camera.x) /
+                game.map.tileSize,
+        );
+        const expectedTileY = Math.floor(
+            ((100 - mockCtx.canvas.height / 2) / game.camera.zoom + game.camera.y) /
+                game.map.tileSize,
+        );
+        game.map.getTile.mockReturnValue(8); // Water tile
+        game.map.findAdjacentFreeTile = jest.fn().mockReturnValue({ x: expectedTileX + 1, y: expectedTileY });
+        game.toggleBuildMode(BUILDING_TYPES.WELL);
+        game.handleClick({ clientX: 100, clientY: 100, target: { closest: () => null } });
+
+        expect(game.map.addBuilding).toHaveBeenCalledTimes(1);
+    });
+
+    test('handleClick should not allow well building on land tile', () => {
+        game.map.getTile.mockReturnValue(0); // Grass tile
+        game.toggleBuildMode(BUILDING_TYPES.WELL);
+        game.handleClick({ clientX: 100, clientY: 100, target: { closest: () => null } });
+
+        expect(game.map.addBuilding).not.toHaveBeenCalled();
     });
 
     test('handleClick should allow building on floor over water tile', () => {

--- a/__tests__/Well.test.js
+++ b/__tests__/Well.test.js
@@ -1,0 +1,14 @@
+import Well from '../src/js/well.js';
+import SpriteManager from '../src/js/spriteManager.js';
+import { BUILDING_TYPES, RESOURCE_TYPES } from '../src/js/constants.js';
+
+describe('Well', () => {
+    test('initializes with correct properties and recipe', () => {
+        const well = new Well(0, 0, new SpriteManager());
+        expect(well.type).toBe(BUILDING_TYPES.WELL);
+        expect(well.constructionMaterials[RESOURCE_TYPES.PLANK]).toBe(1);
+        expect(well.constructionMaterials[RESOURCE_TYPES.STONE]).toBe(1);
+        expect(well.constructionMaterials[RESOURCE_TYPES.BUCKET]).toBe(1);
+        expect(well.recipes[0].outputs[0].resourceType).toBe(RESOURCE_TYPES.BUCKET_WATER);
+    });
+});

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -15,7 +15,8 @@ export const BUILDING_TYPES = {
   ANIMAL_PEN: 'animal_pen',
   BARRICADE: 'barricade',
   BED: 'bed',
-  TABLE: 'table'
+  TABLE: 'table',
+  WELL: 'well'
 };
 
 // Properties for each building type
@@ -28,7 +29,8 @@ export const BUILDING_TYPE_PROPERTIES = {
   [BUILDING_TYPES.ANIMAL_PEN]: { passable: true },
   [BUILDING_TYPES.BARRICADE]: { passable: true },
   [BUILDING_TYPES.BED]: { passable: true },
-  [BUILDING_TYPES.TABLE]: { passable: true }
+  [BUILDING_TYPES.TABLE]: { passable: true },
+  [BUILDING_TYPES.WELL]: { passable: true }
 };
 
 // Resource types used throughout the game
@@ -46,7 +48,8 @@ export const RESOURCE_TYPES = {
   BANDAGE: 'bandage',
   PLANK: 'plank',
   BUCKET: 'bucket',
-  BLOCK: 'block'
+  BLOCK: 'block',
+  BUCKET_WATER: 'bucket_water'
 };
 
 // Categories assigned to each resource. Resources can belong to multiple
@@ -65,7 +68,8 @@ export const RESOURCE_CATEGORIES = {
   [RESOURCE_TYPES.BANDAGE]: ['medical'],
   [RESOURCE_TYPES.PLANK]: ['material'],
   [RESOURCE_TYPES.BUCKET]: ['material'],
-  [RESOURCE_TYPES.BLOCK]: ['material']
+  [RESOURCE_TYPES.BLOCK]: ['material'],
+  [RESOURCE_TYPES.BUCKET_WATER]: ['material']
 };
 
 // Hunger restored when consuming one unit of each food resource

--- a/src/js/craftingStation.js
+++ b/src/js/craftingStation.js
@@ -4,8 +4,18 @@ import Recipe from './recipe.js';
 import { RESOURCE_TYPES, BUILDING_TYPES } from './constants.js';
 
 export default class CraftingStation extends Building {
-    constructor(x, y, spriteManager = null) {
-        super(BUILDING_TYPES.CRAFTING_STATION, x, y, 1, 1, RESOURCE_TYPES.WOOD, 0);
+    constructor(x, y, spriteManager = null, constructionMaterials = null) {
+        super(
+            BUILDING_TYPES.CRAFTING_STATION,
+            x,
+            y,
+            1,
+            1,
+            RESOURCE_TYPES.WOOD,
+            0,
+            1,
+            constructionMaterials,
+        );
         this.drawBase = false;
         this.spriteManager = spriteManager;
         this.stationSprite = spriteManager ? spriteManager.getSprite(BUILDING_TYPES.CRAFTING_STATION) : null;

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -742,6 +742,14 @@ export default class Game {
                 debugLog('Cannot build here. Only floors or wells can be built on water tiles.');
                 return;
             }
+            if (this.selectedBuilding === BUILDING_TYPES.WELL && clickedTile !== 8) {
+                debugLog('Wells can only be built on water tiles.');
+                return;
+            }
+            if (this.selectedBuilding === BUILDING_TYPES.WELL && existingBuilding) {
+                debugLog('Wells must be built on an empty water tile.');
+                return;
+            }
             // Place the selected building
             let newBuilding;
             if (this.selectedBuilding === BUILDING_TYPES.CRAFTING_STATION) {

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -2,6 +2,7 @@ import ResourcePile from './resourcePile.js';
 import Building from './building.js';
 import CraftingStation from './craftingStation.js';
 import Oven from './oven.js';
+import Well from './well.js';
 import FarmPlot from './farmPlot.js';
 import AnimalPen from './animalPen.js';
 import Furniture from './furniture.js';
@@ -286,6 +287,8 @@ export default class Map {
                 building = new CraftingStation(buildingData.x, buildingData.y, this.spriteManager);
             } else if (buildingData.type === BUILDING_TYPES.OVEN) {
                 building = new Oven(buildingData.x, buildingData.y, this.spriteManager);
+            } else if (buildingData.type === BUILDING_TYPES.WELL) {
+                building = new Well(buildingData.x, buildingData.y, this.spriteManager);
             } else if (buildingData.type === BUILDING_TYPES.FARM_PLOT) {
                 building = new FarmPlot(buildingData.x, buildingData.y, this.spriteManager);
             } else if (buildingData.type === BUILDING_TYPES.ANIMAL_PEN) {

--- a/src/js/resourcePile.js
+++ b/src/js/resourcePile.js
@@ -40,6 +40,7 @@ export default class ResourcePile extends Resource {
         const ironOrePileSprite = this.spriteManager.getSprite('iron_ore_pile');
         const plankSprite = this.spriteManager.getSprite(RESOURCE_TYPES.PLANK);
         const bucketSprite = this.spriteManager.getSprite(RESOURCE_TYPES.BUCKET);
+        const bucketWaterSprite = this.spriteManager.getSprite(RESOURCE_TYPES.BUCKET_WATER);
         if (this.type === RESOURCE_TYPES.WOOD && woodSprite) {
             ctx.drawImage(woodSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
         } else if (this.type === RESOURCE_TYPES.STONE && stonePileSprite) {
@@ -66,6 +67,8 @@ export default class ResourcePile extends Resource {
             ctx.drawImage(plankSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
         } else if (this.type === RESOURCE_TYPES.BUCKET && bucketSprite) {
             ctx.drawImage(bucketSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
+        } else if (this.type === RESOURCE_TYPES.BUCKET_WATER && bucketWaterSprite) {
+            ctx.drawImage(bucketWaterSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
         }
         else {
             ctx.fillStyle = 'brown'; // Placeholder color for wood piles

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -401,6 +401,7 @@ export default class UI {
                 createButton('Build Floor', BUILDING_TYPES.FLOOR, false, 'Lays down a floor tile.');
                 createButton('Build Crafting Station', BUILDING_TYPES.CRAFTING_STATION, false, 'Allows settlers to craft items.');
                 createButton('Build Oven', BUILDING_TYPES.OVEN, false, 'Bakes bread from wheat.');
+                createButton('Build Well', BUILDING_TYPES.WELL, false, 'Provides water from water tiles.');
                 createButton('Build Farm Plot', BUILDING_TYPES.FARM_PLOT, false, 'Used for growing crops.');
                 createButton('Build Animal Pen', BUILDING_TYPES.ANIMAL_PEN, false, 'Houses livestock.');
                 createButton('Build Barricade', BUILDING_TYPES.BARRICADE, false, 'A simple defensive barrier.');

--- a/src/js/well.js
+++ b/src/js/well.js
@@ -1,0 +1,33 @@
+import CraftingStation from './craftingStation.js';
+import Recipe from './recipe.js';
+import { BUILDING_TYPES, RESOURCE_TYPES, BUILDING_TYPE_PROPERTIES } from './constants.js';
+
+export default class Well extends CraftingStation {
+    constructor(x, y, spriteManager = null) {
+        const materials = {
+            [RESOURCE_TYPES.PLANK]: 1,
+            [RESOURCE_TYPES.STONE]: 1,
+            [RESOURCE_TYPES.BUCKET]: 1,
+        };
+        super(x, y, spriteManager, materials);
+        this.type = BUILDING_TYPES.WELL;
+        this.material = RESOURCE_TYPES.PLANK;
+        this.constructionMaterials = materials;
+        this.resourcesRequired = Object.values(materials).reduce((a, b) => a + b, 0);
+        this.resourcesDelivered = 0;
+        this.passable = BUILDING_TYPE_PROPERTIES[this.type]?.passable ?? true;
+        this.stationSprite = spriteManager ? spriteManager.getSprite(BUILDING_TYPES.WELL) : null;
+        this.recipes = [];
+        this.autoCraft = false;
+        this.desiredRecipe = null;
+        this.drawBase = false;
+        this.addRecipe(
+            new Recipe(
+                'Water bucket',
+                [{ resourceType: RESOURCE_TYPES.BUCKET, quantity: 1 }],
+                [{ resourceType: RESOURCE_TYPES.BUCKET_WATER, quantity: 1, quality: 1 }],
+                1,
+            ),
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a `Well` crafting building that can be placed on water tiles
- support multiple construction materials in `Building`
- add `BUCKET_WATER` resource type
- load new sprites and expose Well from the build menu
- update game logic and tests for new building

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887a54a38108323bbce812b1d032bcf