### PR TITLE
Add meal cooking feature

### DIFF
--- a/__tests__/Game.test.js
+++ b/__tests__/Game.test.js
@@ -399,6 +399,21 @@ describe('Game', () => {
         expect(game.taskManager.addTask).not.toHaveBeenCalled();
     });
 
+    test('addPrepareMealTask queues prepare meal task', () => {
+        const oven = { x: 1, y: 1, buildProgress: 100 };
+        game.addPrepareMealTask(oven);
+        expect(game.taskManager.addTask).toHaveBeenCalledTimes(1);
+        const task = game.taskManager.addTask.mock.calls[0][0];
+        expect(task.type).toBe(TASK_TYPES.PREPARE_MEAL);
+        expect(task.building).toBe(oven);
+    });
+
+    test('addPrepareMealTask does not queue when oven not built', () => {
+        const oven = { x: 1, y: 1, buildProgress: 20 };
+        game.addPrepareMealTask(oven);
+        expect(game.taskManager.addTask).not.toHaveBeenCalled();
+    });
+
     test('handleClick marks dead enemy for butchering', () => {
         game.map.tileSize = 32;
         const tileX = Math.floor(((100 - mockCtx.canvas.width / 2) / game.camera.zoom + game.camera.x) / game.map.tileSize);

--- a/__tests__/Game.test.js
+++ b/__tests__/Game.test.js
@@ -399,13 +399,19 @@ describe('Game', () => {
         expect(game.taskManager.addTask).not.toHaveBeenCalled();
     });
 
-    test('addPrepareMealTask queues prepare meal task', () => {
+    test('addPrepareMealTask queues haul and prepare tasks', () => {
         const oven = { x: 1, y: 1, buildProgress: 100 };
+        game.roomManager.findHighestValueFoods = jest.fn().mockReturnValue([
+            { type: 'meat', value: 30 },
+            { type: 'bread', value: 20 },
+        ]);
         game.addPrepareMealTask(oven);
-        expect(game.taskManager.addTask).toHaveBeenCalledTimes(1);
-        const task = game.taskManager.addTask.mock.calls[0][0];
-        expect(task.type).toBe(TASK_TYPES.PREPARE_MEAL);
-        expect(task.building).toBe(oven);
+        expect(game.taskManager.addTask).toHaveBeenCalledTimes(3);
+        const haulTask = game.taskManager.addTask.mock.calls[0][0];
+        expect(haulTask.type).toBe(TASK_TYPES.HAUL);
+        const mealTask = game.taskManager.addTask.mock.calls[2][0];
+        expect(mealTask.type).toBe(TASK_TYPES.PREPARE_MEAL);
+        expect(mealTask.building).toBe(oven);
     });
 
     test('addPrepareMealTask does not queue when oven not built', () => {

--- a/__tests__/RoomManager.test.js
+++ b/__tests__/RoomManager.test.js
@@ -2,7 +2,7 @@ import Map from '../src/js/map.js';
 import RoomManager from '../src/js/roomManager.js';
 import ResourcePile from '../src/js/resourcePile.js';
 import TaskManager from '../src/js/taskManager.js';
-import { TASK_TYPES } from '../src/js/constants.js';
+import { TASK_TYPES, RESOURCE_TYPES, FOOD_HUNGER_VALUES } from '../src/js/constants.js';
 
 describe('RoomManager storage rules', () => {
     test('should not allow multiple piles on the same storage tile', () => {
@@ -63,5 +63,20 @@ describe('RoomManager storage rules', () => {
         roomManager.assignHaulingTasksForDroppedPiles(settlers);
 
         expect(taskManager.tasks.length).toBe(0);
+    });
+
+    test('findHighestValueFoods returns top foods excluding meals', () => {
+        const map = new Map(5, 5, 32, { getSprite: jest.fn() });
+        const roomManager = new RoomManager(map, { getSprite: jest.fn() }, 32);
+        const room = roomManager.designateRoom(0, 0, 1, 1, 'storage');
+        room.storage[RESOURCE_TYPES.BERRIES] = 1; // value 10
+        room.storage[RESOURCE_TYPES.MEAT] = 1; // value 30
+        room.storage[RESOURCE_TYPES.BREAD] = 1; // value 20
+        room.storage[RESOURCE_TYPES.MEAL] = 1; // should be ignored
+
+        const foods = roomManager.findHighestValueFoods(2);
+        expect(foods.length).toBe(2);
+        expect(foods[0].type).toBe(RESOURCE_TYPES.MEAT);
+        expect(foods[1].type).toBe(RESOURCE_TYPES.BREAD);
     });
 });

--- a/__tests__/RoomManager.test.js
+++ b/__tests__/RoomManager.test.js
@@ -79,4 +79,28 @@ describe('RoomManager storage rules', () => {
         expect(foods[0].type).toBe(RESOURCE_TYPES.MEAT);
         expect(foods[1].type).toBe(RESOURCE_TYPES.BREAD);
     });
+
+    test('findHighestValueFoods returns duplicates when quantity allows', () => {
+        const map = new Map(5, 5, 32, { getSprite: jest.fn() });
+        const roomManager = new RoomManager(map, { getSprite: jest.fn() }, 32);
+        const room = roomManager.designateRoom(0, 0, 1, 1, 'storage');
+        room.storage[RESOURCE_TYPES.MEAT] = 2;
+
+        const foods = roomManager.findHighestValueFoods(2);
+        expect(foods.length).toBe(2);
+        expect(foods[0].type).toBe(RESOURCE_TYPES.MEAT);
+        expect(foods[1].type).toBe(RESOURCE_TYPES.MEAT);
+    });
+
+    test('removeResourceFromStorage reduces piles and counts', () => {
+        const map = new Map(5, 5, 32, { getSprite: jest.fn() });
+        const roomManager = new RoomManager(map, { getSprite: jest.fn() }, 32);
+        const room = roomManager.designateRoom(0, 0, 0, 0, 'storage');
+        roomManager.addResourceToStorage(room, RESOURCE_TYPES.BREAD, 2);
+
+        const removed = roomManager.removeResourceFromStorage(room, RESOURCE_TYPES.BREAD, 2);
+        expect(removed).toBe(true);
+        expect(room.storage[RESOURCE_TYPES.BREAD]).toBe(0);
+        expect(map.resourcePiles.length).toBe(0);
+    });
 });

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -49,7 +49,8 @@ export const RESOURCE_TYPES = {
   PLANK: 'plank',
   BUCKET: 'bucket',
   BLOCK: 'block',
-  BUCKET_WATER: 'bucket_water'
+  BUCKET_WATER: 'bucket_water',
+  MEAL: 'meal'
 };
 
 // Categories assigned to each resource. Resources can belong to multiple
@@ -69,7 +70,8 @@ export const RESOURCE_CATEGORIES = {
   [RESOURCE_TYPES.PLANK]: ['material'],
   [RESOURCE_TYPES.BUCKET]: ['material'],
   [RESOURCE_TYPES.BLOCK]: ['material'],
-  [RESOURCE_TYPES.BUCKET_WATER]: ['material']
+  [RESOURCE_TYPES.BUCKET_WATER]: ['material'],
+  [RESOURCE_TYPES.MEAL]: ['food']
 };
 
 // Hunger restored when consuming one unit of each food resource
@@ -78,7 +80,8 @@ export const FOOD_HUNGER_VALUES = {
   [RESOURCE_TYPES.BERRIES]: 10,
   [RESOURCE_TYPES.MUSHROOMS]: 8,
   [RESOURCE_TYPES.MEAT]: 30,
-  [RESOURCE_TYPES.BREAD]: 20
+  [RESOURCE_TYPES.BREAD]: 20,
+  [RESOURCE_TYPES.MEAL]: 0
 };
 
 // Individual task type constants
@@ -93,6 +96,7 @@ export const TASK_TYPES = {
   BUILD: 'build',
   CRAFT: 'craft',
   BAKING: 'baking',
+  PREPARE_MEAL: 'prepare_meal',
   SOW_CROP: 'sow_crop',
   HARVEST_CROP: 'harvest_crop',
   TEND_ANIMALS: 'tend_animals',

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -103,6 +103,7 @@ export default class Game {
                 [BUILDING_TYPES.CRAFTING_STATION, 'src/assets/crafting_station.png'],
                 [BUILDING_TYPES.OVEN, 'src/assets/oven.png'],
                 [RESOURCE_TYPES.BREAD, 'src/assets/bread.png'],
+                [RESOURCE_TYPES.MEAL, 'src/assets/meal.png'],
                 [BUILDING_TYPES.TABLE, 'src/assets/table.png'],
                 [BUILDING_TYPES.BED, 'src/assets/bed.png'],
                 [BUILDING_TYPES.WELL, 'src/assets/well.png'],
@@ -516,6 +517,21 @@ export default class Game {
                 ),
             );
         }
+    }
+
+    addPrepareMealTask(oven) {
+        if (oven.buildProgress < 100) return;
+        this.taskManager.addTask(
+            new Task(
+                TASK_TYPES.PREPARE_MEAL,
+                oven.x,
+                oven.y,
+                null,
+                0,
+                2,
+                oven,
+            ),
+        );
     }
 
     unassignTask(task) {

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -521,17 +521,35 @@ export default class Game {
 
     addPrepareMealTask(oven) {
         if (oven.buildProgress < 100) return;
-        this.taskManager.addTask(
-            new Task(
-                TASK_TYPES.PREPARE_MEAL,
-                oven.x,
-                oven.y,
-                null,
-                0,
-                2,
-                oven,
-            ),
+        const foods = this.roomManager.findHighestValueFoods(2);
+        if (foods.length < 2) return;
+
+        foods.forEach(food => {
+            this.taskManager.addTask(
+                new Task(
+                    TASK_TYPES.HAUL,
+                    oven.x,
+                    oven.y,
+                    food.type,
+                    1,
+                    3,
+                    oven,
+                ),
+            );
+        });
+
+        const mealTask = new Task(
+            TASK_TYPES.PREPARE_MEAL,
+            oven.x,
+            oven.y,
+            null,
+            0,
+            2,
+            oven,
         );
+        mealTask.ingredients = foods.map(f => f.type);
+        mealTask.hungerValue = foods.reduce((sum, f) => sum + f.value, 0);
+        this.taskManager.addTask(mealTask);
     }
 
     unassignTask(task) {

--- a/src/js/resourcePile.js
+++ b/src/js/resourcePile.js
@@ -41,6 +41,7 @@ export default class ResourcePile extends Resource {
         const plankSprite = this.spriteManager.getSprite(RESOURCE_TYPES.PLANK);
         const bucketSprite = this.spriteManager.getSprite(RESOURCE_TYPES.BUCKET);
         const bucketWaterSprite = this.spriteManager.getSprite(RESOURCE_TYPES.BUCKET_WATER);
+        const mealSprite = this.spriteManager.getSprite(RESOURCE_TYPES.MEAL);
         if (this.type === RESOURCE_TYPES.WOOD && woodSprite) {
             ctx.drawImage(woodSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
         } else if (this.type === RESOURCE_TYPES.STONE && stonePileSprite) {
@@ -69,6 +70,8 @@ export default class ResourcePile extends Resource {
             ctx.drawImage(bucketSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
         } else if (this.type === RESOURCE_TYPES.BUCKET_WATER && bucketWaterSprite) {
             ctx.drawImage(bucketWaterSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
+        } else if (this.type === RESOURCE_TYPES.MEAL && mealSprite) {
+            ctx.drawImage(mealSprite, this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
         }
         else {
             ctx.fillStyle = 'brown'; // Placeholder color for wood piles

--- a/src/js/roomManager.js
+++ b/src/js/roomManager.js
@@ -1,7 +1,7 @@
 import { debugLog } from './debug.js';
 import ResourcePile from './resourcePile.js';
 import Task from './task.js';
-import { TASK_TYPES } from './constants.js';
+import { TASK_TYPES, FOOD_HUNGER_VALUES, RESOURCE_TYPES } from './constants.js';
 
 export default class RoomManager {
     constructor(map, spriteManager, tileSize, taskManager = null, settlers = []) {
@@ -172,6 +172,21 @@ export default class RoomManager {
         }
         console.warn(`Room ${room.id} is not a storage room.`);
         return false;
+    }
+
+    findHighestValueFoods(count = 2) {
+        const foods = [];
+        for (const room of this.rooms) {
+            if (room.type !== 'storage') continue;
+            for (const food in FOOD_HUNGER_VALUES) {
+                if (food === RESOURCE_TYPES.MEAL) continue;
+                if (room.storage[food] && room.storage[food] > 0) {
+                    foods.push({ room, type: food, value: FOOD_HUNGER_VALUES[food] });
+                }
+            }
+        }
+        foods.sort((a, b) => b.value - a.value);
+        return foods.slice(0, count);
     }
 
     assignHaulingTasksForDroppedPiles(settlers = this.settlers) {

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -529,19 +529,24 @@ export default class Settler {
                     ) {
                         const oven = this.currentTask.building;
                         if (oven.buildProgress < 100) return;
-                        if (oven.occupant && oven.occupant !== this) return;
-                        if (!oven.occupant) {
-                            oven.occupant = this;
-                            this.currentBuilding = oven;
-                        }
                         if (!this.currentTask.ingredients) return; // Should be set when task was created
 
                         const ready = this.currentTask.ingredients.every(
                             type => oven.getResourceQuantity(type) >= 1,
                         );
                         if (!ready) {
+                            if (oven.occupant === this) {
+                                oven.occupant = null;
+                                this.currentBuilding = null;
+                            }
                             debugLog(`${this.name} is waiting for ingredients to prepare meal.`);
                             return;
+                        }
+
+                        if (oven.occupant && oven.occupant !== this) return;
+                        if (!oven.occupant) {
+                            oven.occupant = this;
+                            this.currentBuilding = oven;
                         }
 
                         if (!this.currentTask.inputsConsumed) {

--- a/src/js/taskManager.js
+++ b/src/js/taskManager.js
@@ -8,6 +8,7 @@ export const TASK_SKILL_MAP = {
     [TASK_TYPES.BUILD]: 'building',
     [TASK_TYPES.CRAFT]: 'crafting',
     [TASK_TYPES.BAKING]: 'baking',
+    [TASK_TYPES.PREPARE_MEAL]: 'baking',
     [TASK_TYPES.SOW_CROP]: 'farming',
     [TASK_TYPES.HARVEST_CROP]: 'farming',
     [TASK_TYPES.TEND_ANIMALS]: 'farming',

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -311,33 +311,32 @@ export default class UI {
         this.craftButton.textContent = 'Craft';
         this.craftButton.onclick = () => {
             if (this.gameInstance && this.selectedCraftingStation) {
-                const recipe = this.selectedCraftingStation.recipes[this.recipeSelect.selectedIndex];
-                this.selectedCraftingStation.desiredRecipe = recipe;
-                const qty = parseInt(this.quantityInput.value, 10) || 1;
-                this.gameInstance.addCraftTask(this.selectedCraftingStation, recipe, qty);
-                if (this.autoCraftCheckbox.checked) {
-                    this.selectedCraftingStation.autoCraft = true;
+                const selectedValue = this.recipeSelect.value;
+                if (
+                    this.selectedCraftingStation.type === BUILDING_TYPES.OVEN &&
+                    selectedValue === 'prepare_meal'
+                ) {
+                    this.gameInstance.addPrepareMealTask(this.selectedCraftingStation);
+                } else {
+                    const recipe = this.selectedCraftingStation.recipes[parseInt(selectedValue, 10)];
+                    this.selectedCraftingStation.desiredRecipe = recipe;
+                    const qty = parseInt(this.quantityInput.value, 10) || 1;
+                    this.gameInstance.addCraftTask(this.selectedCraftingStation, recipe, qty);
+                    if (this.autoCraftCheckbox.checked) {
+                        this.selectedCraftingStation.autoCraft = true;
+                    }
                 }
             }
             this.hideCraftingStationMenu();
         };
         this.craftingStationMenu.appendChild(this.craftButton);
 
-        this.prepareMealButton = document.createElement('button');
-        this.prepareMealButton.textContent = 'Prepare Meal';
-        this.prepareMealButton.onclick = () => {
-            if (this.gameInstance && this.selectedCraftingStation) {
-                this.gameInstance.addPrepareMealTask(this.selectedCraftingStation);
-            }
-            this.hideCraftingStationMenu();
-        };
-        this.craftingStationMenu.appendChild(this.prepareMealButton);
-
         this.autoCraftCheckbox.addEventListener('change', () => {
             if (this.selectedCraftingStation) {
                 this.selectedCraftingStation.autoCraft = this.autoCraftCheckbox.checked;
-                if (this.autoCraftCheckbox.checked) {
-                    this.selectedCraftingStation.desiredRecipe = this.selectedCraftingStation.recipes[this.recipeSelect.selectedIndex];
+                const val = this.recipeSelect.value;
+                if (this.autoCraftCheckbox.checked && val !== 'prepare_meal') {
+                    this.selectedCraftingStation.desiredRecipe = this.selectedCraftingStation.recipes[parseInt(val, 10)];
                 }
             }
         });
@@ -643,14 +642,15 @@ export default class UI {
             option.textContent = recipe.name;
             this.recipeSelect.appendChild(option);
         });
+        if (station.type === BUILDING_TYPES.OVEN) {
+            const mealOption = document.createElement('option');
+            mealOption.value = 'prepare_meal';
+            mealOption.textContent = 'Prepare Meal';
+            this.recipeSelect.appendChild(mealOption);
+        }
         this.recipeSelect.selectedIndex = 0;
         this.quantityInput.value = '1';
         this.autoCraftCheckbox.checked = station.autoCraft;
-        if (station.type === BUILDING_TYPES.OVEN) {
-            this.prepareMealButton.style.display = 'inline-block';
-        } else {
-            this.prepareMealButton.style.display = 'none';
-        }
         this.craftingStationMenu.style.left = `${screenX}px`;
         this.craftingStationMenu.style.top = `${screenY}px`;
         this.craftingStationMenu.style.display = 'block';

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -323,6 +323,16 @@ export default class UI {
         };
         this.craftingStationMenu.appendChild(this.craftButton);
 
+        this.prepareMealButton = document.createElement('button');
+        this.prepareMealButton.textContent = 'Prepare Meal';
+        this.prepareMealButton.onclick = () => {
+            if (this.gameInstance && this.selectedCraftingStation) {
+                this.gameInstance.addPrepareMealTask(this.selectedCraftingStation);
+            }
+            this.hideCraftingStationMenu();
+        };
+        this.craftingStationMenu.appendChild(this.prepareMealButton);
+
         this.autoCraftCheckbox.addEventListener('change', () => {
             if (this.selectedCraftingStation) {
                 this.selectedCraftingStation.autoCraft = this.autoCraftCheckbox.checked;
@@ -636,6 +646,11 @@ export default class UI {
         this.recipeSelect.selectedIndex = 0;
         this.quantityInput.value = '1';
         this.autoCraftCheckbox.checked = station.autoCraft;
+        if (station.type === BUILDING_TYPES.OVEN) {
+            this.prepareMealButton.style.display = 'inline-block';
+        } else {
+            this.prepareMealButton.style.display = 'none';
+        }
         this.craftingStationMenu.style.left = `${screenX}px`;
         this.craftingStationMenu.style.top = `${screenY}px`;
         this.craftingStationMenu.style.display = 'block';


### PR DESCRIPTION
## Summary
- define `meal` resource type and new `prepare_meal` task
- load sprite for meals and add UI button for ovens
- support rendering meal piles
- implement prepare meal logic for settlers
- add helper to choose highest value foods
- cover new behaviour with tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6887ae4d6940832393ddbff19dbf39d2