### PR TITLE
Rename baking skill to cooking

### DIFF
--- a/__tests__/Settler.test.js
+++ b/__tests__/Settler.test.js
@@ -63,7 +63,7 @@ describe('Settler', () => {
             mining: 1,
             building: 1,
             crafting: 1,
-            baking: 1,
+            cooking: 1,
             combat: 1,
             medical: 1
         });
@@ -186,10 +186,10 @@ describe('Settler', () => {
         expect(settler.calculateOutputQuality(1)).toBe(2);
     });
 
-    test('calculateOutputQuality uses baking skill when crafting at an oven', () => {
+    test('calculateOutputQuality uses cooking skill when crafting at an oven', () => {
         const ovenBuilding = { type: BUILDING_TYPES.OVEN };
         settler.currentTask = new Task(TASK_TYPES.CRAFT, 0, 0, null, 0, 3, ovenBuilding);
-        settler.skills.baking = 3;
+        settler.skills.cooking = 3;
         expect(settler.calculateOutputQuality(1)).toBeCloseTo(1.2);
     });
 

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -37,7 +37,7 @@ export default class Settler {
             mining: 1,
             building: 1,
             crafting: 1,
-            baking: 1,
+            cooking: 1,
             combat: 1,
             medical: 1
         };
@@ -941,7 +941,7 @@ export default class Settler {
             this.currentTask.building &&
             this.currentTask.building.type === BUILDING_TYPES.OVEN
         ) {
-            skillLevel = this.skills.baking;
+            skillLevel = this.skills.cooking;
         }
         // Simple quality calculation: baseQuality + (skillLevel - 1) * 0.1
         const skillBonus = (skillLevel - 1) * 0.1;

--- a/src/js/taskManager.js
+++ b/src/js/taskManager.js
@@ -7,8 +7,8 @@ import { TASK_TYPES } from './constants.js';
 export const TASK_SKILL_MAP = {
     [TASK_TYPES.BUILD]: 'building',
     [TASK_TYPES.CRAFT]: 'crafting',
-    [TASK_TYPES.BAKING]: 'baking',
-    [TASK_TYPES.PREPARE_MEAL]: 'baking',
+    [TASK_TYPES.BAKING]: 'cooking',
+    [TASK_TYPES.PREPARE_MEAL]: 'cooking',
     [TASK_TYPES.SOW_CROP]: 'farming',
     [TASK_TYPES.HARVEST_CROP]: 'farming',
     [TASK_TYPES.TEND_ANIMALS]: 'farming',


### PR DESCRIPTION
## Summary
- rename settler skill `baking` to `cooking`
- update task skill map to use new skill name
- adjust related tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6887c6cb472483238709b521699686c2