### PR TITLE
Update resource discovery event

### DIFF
--- a/__tests__/EventManager.test.js
+++ b/__tests__/EventManager.test.js
@@ -16,7 +16,7 @@ describe('EventManager', () => {
         game = {
             settlers: [{ name: 'Alice', x: 1, y: 1, takeDamage: jest.fn() }],
             enemies: [],
-            map: { buildings: [] },
+            map: { buildings: [], addResourcePile: jest.fn(), tileSize: 1 },
             resourceManager: { addResource: jest.fn() },
             notificationManager: { addNotification: jest.fn() }
         };
@@ -42,7 +42,7 @@ describe('EventManager', () => {
         );
     });
 
-    test('Resource Discovery adds resource and notification', () => {
+    test('Resource Discovery creates pile and adds notification', () => {
         const manager = new EventManager(game, EnemyStub);
         jest.spyOn(Math, 'random')
             .mockReturnValueOnce(0.3) // pick Resource Discovery event
@@ -50,7 +50,12 @@ describe('EventManager', () => {
             .mockReturnValueOnce(0);    // quantity -> 20
         manager.triggerRandomEvent();
         Math.random.mockRestore();
-        expect(game.resourceManager.addResource).toHaveBeenCalledWith('wood', 20);
+        expect(game.map.addResourcePile).toHaveBeenCalled();
+        const createdPile = game.map.addResourcePile.mock.calls[0][0];
+        expect(createdPile.type).toBe('wood');
+        expect(createdPile.quantity).toBe(20);
+        expect(createdPile.x).toBe(0);
+        expect(createdPile.y).toBe(0);
         expect(game.notificationManager.addNotification).toHaveBeenCalledWith(
             'You discovered a new resource node!',
             'info'

--- a/src/js/eventManager.js
+++ b/src/js/eventManager.js
@@ -51,9 +51,20 @@ export default class EventManager {
                     const resourceTypes = [RESOURCE_TYPES.WOOD, RESOURCE_TYPES.STONE, RESOURCE_TYPES.IRON_ORE];
                     const randomResource = resourceTypes[Math.floor(Math.random() * resourceTypes.length)];
                     const quantity = Math.floor(Math.random() * 50) + 20; // 20-70 units
-                    this.game.resourceManager.addResource(randomResource, quantity);
-                    debugLog(`Discovered ${quantity} units of ${randomResource}!`);
-                    this.game.notificationManager.addNotification(`Discovered ${quantity} units of ${randomResource}!`, 'info');
+                    const pile = new ResourcePile(
+                        randomResource,
+                        quantity,
+                        0,
+                        0,
+                        this.game.map.tileSize,
+                        this.game.spriteManager
+                    );
+                    this.game.map.addResourcePile(pile);
+                    debugLog(`Discovered ${quantity} units of ${randomResource} at (0,0)!`);
+                    this.game.notificationManager.addNotification(
+                        `Discovered ${quantity} units of ${randomResource}!`,
+                        'info'
+                    );
                 }
             },
             {


### PR DESCRIPTION
## Summary
- drop resource piles at the origin when a resource discovery event occurs
- adjust tests for new resource pile behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6887d00765f88323bccc77d2b20b2368