### PR TITLE
Fix room serialization for save/load

### DIFF
--- a/__tests__/RoomManager.test.js
+++ b/__tests__/RoomManager.test.js
@@ -103,4 +103,23 @@ describe('RoomManager storage rules', () => {
         expect(room.storage[RESOURCE_TYPES.BREAD]).toBe(0);
         expect(map.resourcePiles.length).toBe(0);
     });
+
+    test('serialize and deserialize restore rooms and grid', () => {
+        const map = new Map(5, 5, 32, { getSprite: jest.fn() });
+        const rm1 = new RoomManager(map, { getSprite: jest.fn() }, 32);
+        const room = rm1.designateRoom(0, 0, 1, 1, 'storage');
+        room.storage[RESOURCE_TYPES.WOOD] = 10;
+
+        const data = rm1.serialize();
+
+        const rm2 = new RoomManager(map, { getSprite: jest.fn() }, 32);
+        rm2.deserialize(data);
+
+        expect(rm2.rooms.length).toBe(1);
+        const loadedRoom = rm2.rooms[0];
+        expect(loadedRoom.type).toBe('storage');
+        expect(loadedRoom.storage[RESOURCE_TYPES.WOOD]).toBe(10);
+        expect(rm2.getRoomAt(0, 0)).toBe(loadedRoom);
+        expect(rm2.getRoomAt(1, 1)).toBe(loadedRoom);
+    });
 });

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -565,6 +565,7 @@ export default class Game {
             settlers: this.settlers.map(settler => settler.serialize()),
             resources: this.resourceManager.serialize(),
             map: this.map.serialize(),
+            rooms: this.roomManager.serialize(),
             gameTime: this.gameTime,
             gameSpeed: this.gameSpeed,
             temperature: this.temperature,
@@ -614,6 +615,7 @@ export default class Game {
 
             // Restore map (buildings, resource piles)
             this.map.deserialize(gameState.map);
+            this.roomManager.deserialize(gameState.rooms);
 
             this.gameTime = gameState.gameTime;
             this.gameSpeed = gameState.gameSpeed;

--- a/src/js/roomManager.js
+++ b/src/js/roomManager.js
@@ -235,6 +235,41 @@ export default class RoomManager {
         }
     }
 
+    serialize() {
+        return {
+            rooms: this.rooms.map(room => ({
+                id: room.id,
+                type: room.type,
+                tiles: room.tiles,
+                storage: room.storage
+            }))
+        };
+    }
+
+    deserialize(data) {
+        this.rooms = data.rooms.map(roomData => ({
+            id: roomData.id,
+            type: roomData.type,
+            tiles: roomData.tiles,
+            storage: roomData.storage || {}
+        }));
+        this.roomGrid = Array(this.map.height)
+            .fill(0)
+            .map(() => Array(this.map.width).fill(null));
+        this.rooms.forEach(room => {
+            room.tiles.forEach(tile => {
+                if (
+                    tile.x >= 0 &&
+                    tile.x < this.map.width &&
+                    tile.y >= 0 &&
+                    tile.y < this.map.height
+                ) {
+                    this.roomGrid[tile.y][tile.x] = room;
+                }
+            });
+        });
+    }
+
     // Future: removeRoom, getRoomsByType, etc.
 
     render(ctx, tileSize) {


### PR DESCRIPTION
## Summary
- add serialize/deserialize methods to `RoomManager`
- persist room data in `Game.saveGame` and restore in `Game.loadGame`
- test room manager serialization

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6887d810f41c8323b501324285eafdef