### PR TITLE
Implement auto-pausing for frequently unassigned tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Noits is a 2D medieval colony management game built entirely with vanilla JavaSc
 - **Resource System**: Storage room system with piles for resources. Settlers gather wood, stone, ores and forage for berries or mushrooms.
 - **Settlers with Needs**: Hunger and sleep drive behaviour. Settlers pursue tasks through a simple AI and mood system.
 - **Task Queue**: Prioritised tasks for chopping trees, mining, hauling, farming and more.
+- **Automatic Task Pausing**: Tasks that get unassigned repeatedly are paused to prevent infinite reassignment.
 - **Building Construction**: Place walls, floors and furniture. Buildings require materials and have health.
 - **Crafting & Production**: Crafting stations, ovens and wells convert resources into useful items.
 - **Farming & Husbandry**: Farm plots grow crops like wheat or cotton. Animal pens hold livestock.

--- a/__tests__/GameAutoPauseTask.test.js
+++ b/__tests__/GameAutoPauseTask.test.js
@@ -1,0 +1,39 @@
+import Game from '../src/js/game.js';
+import Settler from '../src/js/settler.js';
+import Task from '../src/js/task.js';
+import { TASK_TYPES } from '../src/js/constants.js';
+
+describe('Game auto pause task', () => {
+    test('task pauses after being unassigned more than 5 times within a second', () => {
+        jest.spyOn(Date, 'now')
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(100)
+            .mockReturnValueOnce(200)
+            .mockReturnValueOnce(300)
+            .mockReturnValueOnce(400)
+            .mockReturnValueOnce(500)
+            .mockReturnValue(600);
+
+        const ctx = { canvas: { width: 800, height: 600 }, clearRect: jest.fn(), drawImage: jest.fn() };
+        const game = new Game(ctx);
+        const alice = new Settler('Alice', 0, 0, game.resourceManager, game.map, game.roomManager, game.spriteManager, game.settlers);
+        alice.updateNeeds = jest.fn();
+        alice.state = 'idle';
+        game.settlers = [alice];
+        game.roomManager.setSettlers(game.settlers);
+
+        const task = new Task(TASK_TYPES.BUILD, 1, 1);
+        game.taskManager.addTask(task);
+
+        game.update(16);
+
+        for (let i = 0; i < 6; i++) {
+            game.unassignTask(task);
+            game.update(16);
+        }
+
+        expect(task.paused).toBe(true);
+
+        Date.now.mockRestore();
+    });
+});

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -511,6 +511,12 @@ export default class Game {
     }
 
     unassignTask(task) {
+        const now = Date.now();
+        task.unassignTimestamps = task.unassignTimestamps.filter(t => now - t < 1000);
+        task.unassignTimestamps.push(now);
+        if (task.unassignTimestamps.length > 5) {
+            task.paused = true;
+        }
         if (!task.assigned) return;
         const settler = this.settlers.find(s => s.name === task.assigned);
         if (settler && settler.currentTask === task) {

--- a/src/js/task.js
+++ b/src/js/task.js
@@ -19,6 +19,7 @@ export default class Task {
         this.targetEnemy = targetEnemy; // For butcher tasks
         this.sourceX = sourceX; // For haul tasks from a source tile
         this.sourceY = sourceY; // For haul tasks from a source tile
+        this.unassignTimestamps = []; // Track when the task was unassigned
     }
 
     serialize() {
@@ -42,6 +43,7 @@ export default class Task {
             targetEnemy: this.targetEnemy ? { id: this.targetEnemy.id } : null,
             sourceX: this.sourceX,
             sourceY: this.sourceY,
+            unassignTimestamps: this.unassignTimestamps,
         };
     }
 
@@ -66,5 +68,6 @@ export default class Task {
         this.targetEnemy = data.targetEnemy; // Store raw data for now
         this.sourceX = data.sourceX;
         this.sourceY = data.sourceY;
+        this.unassignTimestamps = data.unassignTimestamps || [];
     }
 }


### PR DESCRIPTION
## Summary
- track unassign timestamps on `Task`
- auto-pause tasks that are unassigned repeatedly
- test new behaviour with `GameAutoPauseTask.test.js`
- document automatic task pausing in README

## Testing
- `npm run lint --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68886030f0848323b925a7eaf0fb0438