### PR TITLE
Add dev menu event trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Noits is a 2D medieval colony management game built entirely with vanilla JavaSc
 - **Rooms & Storage**: Designate rooms (bedrooms, storage) and manage inventories.
 - **UI & Notifications**: Tooltips, overlays and alerts keep you informed.
 - **Save/Load**: Game state can be saved to and loaded from local storage.
+- **Development Menu**: Provides debug tools like manual event triggering.
 
 ## Buildings
 The following building types are available:

--- a/__tests__/UI.test.js
+++ b/__tests__/UI.test.js
@@ -80,6 +80,16 @@ describe('UI tooltips', () => {
         expect(ui.taskManagerButton.parentElement).toBe(ui.devMenu);
     });
 
+    test('trigger event button triggers event manager', () => {
+        const ui = new UI({});
+        const mockGame = { eventManager: { triggerRandomEvent: jest.fn() } };
+        ui.setGameInstance(mockGame);
+        const button = Array.from(ui.devMenu.querySelectorAll('button')).find(b => b.textContent === 'Trigger Event');
+        expect(button).not.toBeNull();
+        button.dispatchEvent(new Event('click'));
+        expect(mockGame.eventManager.triggerRandomEvent).toHaveBeenCalled();
+    });
+
     test('showTaskManager displays tasks and allows deletion', () => {
         const ui = new UI({});
         const task1 = { type: 'build' };

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -153,6 +153,16 @@ export default class UI {
         this.taskManagerButton.onclick = () => this.toggleTaskManager();
         this.devMenu.appendChild(this.taskManagerButton);
 
+        this.triggerEventButton = document.createElement('button');
+        this.triggerEventButton.textContent = 'Trigger Event';
+        this.triggerEventButton.onclick = (event) => {
+            event.stopPropagation();
+            if (this.gameInstance) {
+                this.gameInstance.eventManager.triggerRandomEvent();
+            }
+        };
+        this.devMenu.appendChild(this.triggerEventButton);
+
         this.helpOverlay = document.createElement('div');
         this.helpOverlay.id = 'help-overlay';
         this.helpOverlay.style.display = 'none';


### PR DESCRIPTION
## Summary
- add `Trigger Event` button to dev menu
- trigger random event when clicked
- document development menu in README
- test manual event button

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688866b9753c832395df2de8a93ff2f7