### PR TITLE
Add deer hunting enemy task

### DIFF
--- a/__tests__/Settler.test.js
+++ b/__tests__/Settler.test.js
@@ -292,23 +292,36 @@ describe('Settler', () => {
         expect(settler.currentTask).toBe(null);
     });
 
-    test('should handle hunt_animal task without dropping bandage pile', () => {
-        const task = new Task(TASK_TYPES.HUNT_ANIMAL, 1, 1, 'meat', 0.2);
+    test('should handle hunt_animal task targeting enemy', () => {
+        const mockEnemy = { x: 1, y: 1, isDead: false, name: 'Deer' };
+        const task = new Task(
+            TASK_TYPES.HUNT_ANIMAL,
+            1,
+            1,
+            'meat',
+            0.2,
+            2,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            mockEnemy
+        );
         settler.currentTask = task;
         settler.x = 1;
         settler.y = 1;
-        settler.map.removeResourceNode = jest.fn();
 
         for (let i = 0; i < 5; i++) {
             settler.updateNeeds(1000);
         }
 
-        expect(mockResourceManager.addResource).not.toHaveBeenCalled();
+        expect(mockEnemy.isDead).toBe(true);
         expect(settler.map.addResourcePile).toHaveBeenCalled();
         const meatPile = settler.map.addResourcePile.mock.calls[0][0];
         expect(meatPile.type).toBe('meat');
         expect(meatPile.quantity).toBe(1);
-        expect(settler.carrying).toBe(null);
         expect(settler.currentTask).toBe(null);
     });
 

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -862,9 +862,12 @@ export default class Game {
                 } else if (clickedTile === 6) { // If wild food is clicked
                     this.taskManager.addTask(new Task(TASK_TYPES.MUSHROOM, tileX, tileY, RESOURCE_TYPES.MUSHROOMS, 1, 2));
                     debugLog(`Forage food task added at ${tileX},${tileY}`);
-                } else if (clickedTile === 7) { // If animal is clicked
-                    this.taskManager.addTask(new Task(TASK_TYPES.HUNT_ANIMAL, tileX, tileY, RESOURCE_TYPES.MEAT, 2.5, 2));
-                    debugLog(`Hunt animal task added at ${tileX},${tileY}`);
+                } else {
+                    const targetEnemy = this.enemies.find(e => Math.floor(e.x) === tileX && Math.floor(e.y) === tileY && !e.isDead && e.name === 'Deer');
+                    if (targetEnemy) {
+                        this.taskManager.addTask(new Task(TASK_TYPES.HUNT_ANIMAL, tileX, tileY, RESOURCE_TYPES.MEAT, 2.5, 2, null, null, null, null, null, null, targetEnemy));
+                        debugLog(`Hunt animal task added targeting deer at ${tileX},${tileY}`);
+                    }
                 }
             }
         }

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -47,8 +47,6 @@ export default class Map {
                     tiles[y][x] = 5; // 5 for iron_ore
                 } else if (rand < 0.13) {
                     tiles[y][x] = 6; // 6 for wild food (bush)
-                } else if (rand < 0.15) {
-                    tiles[y][x] = 7; // 7 for animal
                 } else if (rand < 0.25) {
                     tiles[y][x] = 1; // 1 for dirt
                 } else {

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -347,6 +347,23 @@ export default class Settler {
                 }
             }
 
+            // Update hunt target position for moving animals
+            if (
+                this.currentTask.type === TASK_TYPES.HUNT_ANIMAL &&
+                this.currentTask.targetEnemy
+            ) {
+                const ex = Math.floor(this.currentTask.targetEnemy.x);
+                const ey = Math.floor(this.currentTask.targetEnemy.y);
+                if (
+                    this.currentTask.targetX !== ex ||
+                    this.currentTask.targetY !== ey
+                ) {
+                    this.currentTask.targetX = ex;
+                    this.currentTask.targetY = ey;
+                    this.path = null;
+                }
+            }
+
             if (!this.path) {
                 if (Math.floor(this.x) === this.currentTask.targetX && Math.floor(this.y) === this.currentTask.targetY) {
                     this.path = [];
@@ -612,19 +629,41 @@ export default class Settler {
                     } else if (
                         this.currentTask.type === TASK_TYPES.CHOP_WOOD ||
                         this.currentTask.type === TASK_TYPES.GATHER_BERRIES ||
-                        this.currentTask.type === TASK_TYPES.MUSHROOM ||
-                        this.currentTask.type === TASK_TYPES.HUNT_ANIMAL
+                        this.currentTask.type === TASK_TYPES.MUSHROOM
                     ) {
                         const resourceType = this.currentTask.resourceType;
                         const gatheringRate = 0.1; // e.g., 0.1 units of resource per second
                         const amountToGather = gatheringRate * (deltaTime / 1000);
-    
+
                         this.currentTask.quantity -= amountToGather;
     
                         if (this.currentTask.quantity <= 0) {
                             this.pickUpPile(resourceType, 1); // Settler carries the resource
                             this.map.removeResourceNode(this.currentTask.targetX, this.currentTask.targetY);
                             debugLog(`${this.name} completed ${this.currentTask.type} and is now carrying ${this.carrying.type}.`);
+                            this.currentTask = null;
+                            this.path = null;
+                        }
+                    } else if (
+                        this.currentTask.type === TASK_TYPES.HUNT_ANIMAL &&
+                        this.currentTask.targetEnemy
+                    ) {
+                        const huntingRate = 0.1;
+                        const amountToHunt = huntingRate * (deltaTime / 1000);
+                        this.currentTask.quantity -= amountToHunt;
+
+                        if (this.currentTask.quantity <= 0) {
+                            this.currentTask.targetEnemy.isDead = true;
+                            const pile = new ResourcePile(
+                                this.currentTask.resourceType,
+                                1,
+                                Math.floor(this.currentTask.targetEnemy.x),
+                                Math.floor(this.currentTask.targetEnemy.y),
+                                this.map.tileSize,
+                                this.spriteManager,
+                            );
+                            this.map.addResourcePile(pile);
+                            debugLog(`${this.name} hunted ${this.currentTask.targetEnemy.name}.`);
                             this.currentTask = null;
                             this.path = null;
                         }


### PR DESCRIPTION
## Summary
- remove deer tiles from the map generation
- create hunt task when clicking a wild deer enemy
- update settlers to track moving hunt targets and harvest meat from killed deer
- adjust unit test for hunting

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6888687ea0808323bf003a14c0388d83