### PR TITLE
Fix meal hunger use

### DIFF
--- a/__tests__/RoomManager.test.js
+++ b/__tests__/RoomManager.test.js
@@ -99,7 +99,7 @@ describe('RoomManager storage rules', () => {
         roomManager.addResourceToStorage(room, RESOURCE_TYPES.BREAD, 2);
 
         const removed = roomManager.removeResourceFromStorage(room, RESOURCE_TYPES.BREAD, 2);
-        expect(removed).toBe(true);
+        expect(removed).toEqual({ type: RESOURCE_TYPES.BREAD, quantity: 2, hungerRestoration: FOOD_HUNGER_VALUES[RESOURCE_TYPES.BREAD] * 2 });
         expect(room.storage[RESOURCE_TYPES.BREAD]).toBe(0);
         expect(map.resourcePiles.length).toBe(0);
     });


### PR DESCRIPTION
## Summary
- preserve hungerRestoration when picking up and storing resources
- look at meal piles when settlers search for food
- return consumed resource info and use hunger restoration when eating
- adjust tests for new hunger value behavior and add coverage for meals

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68886757a3848323b8938b7a32d6e228