### PR TITLE
Update settler state usage

### DIFF
--- a/src/js/game.js
+++ b/src/js/game.js
@@ -525,6 +525,9 @@ export default class Game {
                 settler.currentBuilding = null;
             }
             settler.currentTask = null;
+            if (settler.state === task.type) {
+                settler.state = 'idle';
+            }
         }
         if (task.building && task.building.occupant === settler) {
             task.building.occupant = null;

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -333,6 +333,7 @@ export default class Settler {
 
         // Execute current task
         if (this.currentTask) {
+            this.state = this.currentTask.type;
             // Ensure hauling tasks head to the resource pile first
             if (
                 this.currentTask.type === TASK_TYPES.HAUL &&
@@ -1200,6 +1201,7 @@ export default class Settler {
             } else {
                 this.currentTask = { ...data.currentTask };
             }
+            this.state = this.currentTask ? this.currentTask.type : this.state;
         }
         // targetEnemy will need to be re-linked by the Game class after all entities are deserialized
         this.targetEnemy = null;

--- a/src/js/taskManager.js
+++ b/src/js/taskManager.js
@@ -129,6 +129,7 @@ export default class TaskManager {
                 }
 
                 bestSettler.currentTask = task;
+                bestSettler.state = task.type;
                 task.assigned = bestSettler.name;
                 if (task.building) {
                     task.building.occupant = bestSettler;


### PR DESCRIPTION
## Summary
- set settler state to the task type when assigned or executing
- clear settler state when unassigning tasks
- restore state from saved tasks on load

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68886fd451e083238c2dd49aea2276aa