### PR TITLE
Add settlers overview dev menu

### DIFF
--- a/__tests__/UI.test.js
+++ b/__tests__/UI.test.js
@@ -103,6 +103,18 @@ describe('UI tooltips', () => {
         expect(ui.settlerOverlay.style.display).toBe('none');
     });
 
+    test('wheel on settler overlay does not bubble to window', () => {
+        const ui = new UI({});
+        ui.setGameInstance({ settlers: [] });
+        ui.showSettlerOverview();
+        const handler = jest.fn();
+        window.addEventListener('wheel', handler);
+        ui.settlerOverlay.dispatchEvent(new Event('wheel', { bubbles: true }));
+        expect(handler).not.toHaveBeenCalled();
+        window.removeEventListener('wheel', handler);
+        ui.hideSettlerOverview();
+    });
+
     test('trigger event button triggers event manager', () => {
         const ui = new UI({});
         const mockGame = { eventManager: { triggerRandomEvent: jest.fn() } };

--- a/__tests__/UI.test.js
+++ b/__tests__/UI.test.js
@@ -80,6 +80,29 @@ describe('UI tooltips', () => {
         expect(ui.taskManagerButton.parentElement).toBe(ui.devMenu);
     });
 
+    test('settlers button is placed in dev menu', () => {
+        const ui = new UI({});
+        const button = Array.from(ui.devMenu.querySelectorAll('button')).find(b => b.textContent === 'Settlers');
+        expect(button).not.toBeNull();
+        expect(button.parentElement).toBe(ui.devMenu);
+    });
+
+    test('showSettlerOverview displays settlers', () => {
+        const ui = new UI({});
+        const settlers = [
+            { name: 'Alice', currentTask: { type: 'build' }, health: 90, hunger: 50, sleep: 60, mood: 80, carrying: { type: 'wood', quantity: 1 } },
+            { name: 'Bob', currentTask: null, health: 100, hunger: 100, sleep: 100, mood: 100, carrying: null }
+        ];
+        const mockGame = { settlers };
+        ui.setGameInstance(mockGame);
+        ui.showSettlerOverview();
+        expect(ui.settlerOverlay.style.display).toBe('block');
+        expect(ui.settlerOverlay.querySelector('table')).not.toBeNull();
+        expect(ui.settlerOverlay.querySelectorAll('tbody tr').length).toBe(2);
+        ui.hideSettlerOverview();
+        expect(ui.settlerOverlay.style.display).toBe('none');
+    });
+
     test('trigger event button triggers event manager', () => {
         const ui = new UI({});
         const mockGame = { eventManager: { triggerRandomEvent: jest.fn() } };

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -124,7 +124,7 @@ input[type="range"] {
 
 #settler-overlay {
     position: fixed;
-    bottom: 10px;
+    bottom: 120px;
     left: 50%;
     transform: translateX(-50%);
     width: 600px;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -122,6 +122,43 @@ input[type="range"] {
     z-index: 1001;
 }
 
+#settler-overlay {
+    position: fixed;
+    bottom: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 600px;
+    max-height: 400px;
+    background-color: rgba(0, 0, 0, 0.8);
+    color: white;
+    border-radius: 5px;
+    padding: 10px;
+    box-sizing: border-box;
+    display: none;
+    overflow-y: auto;
+    z-index: 1001;
+}
+#settler-overlay table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+#settler-overlay th {
+    text-align: left;
+    padding: 5px;
+    border-bottom: 1px solid #444;
+}
+
+#settler-overlay td {
+    padding: 5px;
+}
+
+#settler-overlay .close-button {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+}
+
 #task-overlay table {
     width: 100%;
     border-collapse: collapse;

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -223,6 +223,9 @@ export default class UI {
         this.settlerOverlay.addEventListener('click', (event) => {
             event.stopPropagation();
         });
+        this.settlerOverlay.addEventListener('wheel', (event) => {
+            event.stopPropagation();
+        });
         document.body.appendChild(this.settlerOverlay);
 
         this.farmPlotMenu = document.createElement('div');

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -646,25 +646,33 @@ export default class UI {
 
     renderSettlerOverview(settlers) {
         if (!this.gameInstance) return;
-        this.settlerOverlay.innerHTML = '';
-        const closeBtn = document.createElement('button');
-        closeBtn.textContent = 'X';
-        closeBtn.className = 'close-button';
-        closeBtn.onclick = () => this.hideSettlerOverview();
-        this.settlerOverlay.appendChild(closeBtn);
 
-        const table = document.createElement('table');
-        const thead = document.createElement('thead');
-        const headerRow = document.createElement('tr');
-        ['Name', 'Task', 'Health', 'Hunger', 'Sleep', 'Mood', 'Inventory'].forEach(text => {
-            const th = document.createElement('th');
-            th.textContent = text;
-            headerRow.appendChild(th);
-        });
-        thead.appendChild(headerRow);
-        table.appendChild(thead);
+        if (!this.settlerTable) {
+            this.settlerOverlay.innerHTML = '';
+            const closeBtn = document.createElement('button');
+            closeBtn.textContent = 'X';
+            closeBtn.className = 'close-button';
+            closeBtn.onclick = () => this.hideSettlerOverview();
+            this.settlerOverlay.appendChild(closeBtn);
 
-        const tbody = document.createElement('tbody');
+            this.settlerTable = document.createElement('table');
+            const thead = document.createElement('thead');
+            const headerRow = document.createElement('tr');
+            ['Name', 'Task', 'Health', 'Hunger', 'Sleep', 'Mood', 'Inventory'].forEach(text => {
+                const th = document.createElement('th');
+                th.textContent = text;
+                headerRow.appendChild(th);
+            });
+            thead.appendChild(headerRow);
+            this.settlerTable.appendChild(thead);
+
+            this.settlerTbody = document.createElement('tbody');
+            this.settlerTable.appendChild(this.settlerTbody);
+            this.settlerOverlay.appendChild(this.settlerTable);
+        }
+
+        const tbody = this.settlerTbody;
+        tbody.innerHTML = '';
         settlers.forEach(settler => {
             const row = document.createElement('tr');
             const cells = [
@@ -683,8 +691,6 @@ export default class UI {
             });
             tbody.appendChild(row);
         });
-        table.appendChild(tbody);
-        this.settlerOverlay.appendChild(table);
     }
 
     showSettlerOverview() {

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -153,6 +153,11 @@ export default class UI {
         this.taskManagerButton.onclick = () => this.toggleTaskManager();
         this.devMenu.appendChild(this.taskManagerButton);
 
+        this.settlersButton = document.createElement('button');
+        this.settlersButton.textContent = 'Settlers';
+        this.settlersButton.onclick = () => this.toggleSettlerOverview();
+        this.devMenu.appendChild(this.settlersButton);
+
         this.triggerEventButton = document.createElement('button');
         this.triggerEventButton.textContent = 'Trigger Event';
         this.triggerEventButton.onclick = (event) => {
@@ -208,6 +213,17 @@ export default class UI {
             event.stopPropagation();
         });
         document.body.appendChild(this.taskOverlay);
+
+        this.settlerOverlay = document.createElement('div');
+        this.settlerOverlay.id = 'settler-overlay';
+        this.settlerOverlay.style.display = 'none';
+        this.settlerOverlay.addEventListener('mousedown', (event) => {
+            event.stopPropagation();
+        });
+        this.settlerOverlay.addEventListener('click', (event) => {
+            event.stopPropagation();
+        });
+        document.body.appendChild(this.settlerOverlay);
 
         this.farmPlotMenu = document.createElement('div');
         this.farmPlotMenu.id = 'farm-plot-menu';
@@ -448,11 +464,11 @@ export default class UI {
         this.settlersElement.innerHTML = '';
         settlers.forEach(settler => {
             const settlerDiv = document.createElement('div');
-            settlerDiv.innerHTML = `<strong>${settler.name}</strong> - 
-                Health: <span class="tooltip-trigger" data-tooltip-text="Current Health: ${settler.health.toFixed(1)} / 100">${settler.health.toFixed(1)}</span> | 
-                Hunger: <span class="tooltip-trigger" data-tooltip-text="Hunger: ${settler.hunger.toFixed(1)}%">${settler.hunger.toFixed(1)}</span> | 
-                Sleep: <span class="tooltip-trigger" data-tooltip-text="Sleep: ${settler.sleep.toFixed(1)}%">${settler.sleep.toFixed(1)}</span> | 
-                Mood: <span class="tooltip-trigger" data-tooltip-text="Mood: ${settler.mood.toFixed(1)}%">${settler.mood.toFixed(1)}</span> | 
+            settlerDiv.innerHTML = `<strong>${settler.name}</strong> -
+                Health: <span class="tooltip-trigger" data-tooltip-text="Current Health: ${settler.health.toFixed(1)} / 100">${settler.health.toFixed(1)}</span> |
+                Hunger: <span class="tooltip-trigger" data-tooltip-text="Hunger: ${settler.hunger.toFixed(1)}%">${settler.hunger.toFixed(1)}</span> |
+                Sleep: <span class="tooltip-trigger" data-tooltip-text="Sleep: ${settler.sleep.toFixed(1)}%">${settler.sleep.toFixed(1)}</span> |
+                Mood: <span class="tooltip-trigger" data-tooltip-text="Mood: ${settler.mood.toFixed(1)}%">${settler.mood.toFixed(1)}</span> |
                 Status: <span class="tooltip-trigger" data-tooltip-text="Current Status: ${settler.getStatus()}">${settler.getStatus()}</span>`;
             
             // Attach event listeners to tooltip triggers
@@ -462,6 +478,9 @@ export default class UI {
             });
             this.settlersElement.appendChild(settlerDiv);
         });
+        if (this.settlerOverlay.style.display === 'block') {
+            this.renderSettlerOverview(settlers);
+        }
     }
 
     showHelp() {
@@ -622,6 +641,67 @@ export default class UI {
             this.showTaskManager();
         } else {
             this.hideTaskManager();
+        }
+    }
+
+    renderSettlerOverview(settlers) {
+        if (!this.gameInstance) return;
+        this.settlerOverlay.innerHTML = '';
+        const closeBtn = document.createElement('button');
+        closeBtn.textContent = 'X';
+        closeBtn.className = 'close-button';
+        closeBtn.onclick = () => this.hideSettlerOverview();
+        this.settlerOverlay.appendChild(closeBtn);
+
+        const table = document.createElement('table');
+        const thead = document.createElement('thead');
+        const headerRow = document.createElement('tr');
+        ['Name', 'Task', 'Health', 'Hunger', 'Sleep', 'Mood', 'Inventory'].forEach(text => {
+            const th = document.createElement('th');
+            th.textContent = text;
+            headerRow.appendChild(th);
+        });
+        thead.appendChild(headerRow);
+        table.appendChild(thead);
+
+        const tbody = document.createElement('tbody');
+        settlers.forEach(settler => {
+            const row = document.createElement('tr');
+            const cells = [
+                settler.name,
+                settler.currentTask ? settler.currentTask.type : '',
+                settler.health.toFixed(1),
+                settler.hunger.toFixed(1),
+                settler.sleep.toFixed(1),
+                settler.mood.toFixed(1),
+                settler.carrying ? `${settler.carrying.quantity} ${settler.carrying.type}` : ''
+            ];
+            cells.forEach(text => {
+                const td = document.createElement('td');
+                td.textContent = text;
+                row.appendChild(td);
+            });
+            tbody.appendChild(row);
+        });
+        table.appendChild(tbody);
+        this.settlerOverlay.appendChild(table);
+    }
+
+    showSettlerOverview() {
+        if (!this.gameInstance) return;
+        this.renderSettlerOverview(this.gameInstance.settlers);
+        this.settlerOverlay.style.display = 'block';
+    }
+
+    hideSettlerOverview() {
+        this.settlerOverlay.style.display = 'none';
+    }
+
+    toggleSettlerOverview() {
+        if (this.settlerOverlay.style.display === 'none') {
+            this.showSettlerOverview();
+        } else {
+            this.hideSettlerOverview();
         }
     }
 


### PR DESCRIPTION
## Summary
- add Settlers button to the dev menu
- show settler details overlay with table listing task, needs and inventory
- keep overlay updated while visible
- style new overlay in CSS
- test Settlers button and overlay behaviour

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6888a640c5548323a0c4a069b3819c6f