### PR TITLE
Remove health overlay from canvas

### DIFF
--- a/src/js/enemy.js
+++ b/src/js/enemy.js
@@ -165,7 +165,6 @@ export default class Enemy {
         ctx.fillStyle = 'white';
         ctx.font = '10px Arial';
         ctx.fillText(this.name, this.x * 32, this.y * 32 - 5);
-        ctx.fillText(`Health: ${this.health.toFixed(1)}`, this.x * 32, this.y * 32 + 40);
     }
 
     serialize() {

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -991,9 +991,6 @@ export default class Settler {
         ctx.fillStyle = 'white';
         ctx.font = '10px Arial';
         ctx.fillText(this.name, this.x * 32, this.y * 32 - 5);
-        ctx.fillText(this.state, this.x * 32, this.y * 32 + 40);
-        ctx.fillText(this.getStatus(), this.x * 32, this.y * 32 + 50);
-        ctx.fillText(`Health: ${this.health.toFixed(1)}`, this.x * 32, this.y * 32 + 60);
     }
 
     getStatus() {


### PR DESCRIPTION
## Summary
- remove health and task info from enemy and settler render functions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6888b6cf8b248323b13c787348f66609