### PR TITLE
Add drop shadow to resource pile numbers

### DIFF
--- a/src/js/resourcePile.js
+++ b/src/js/resourcePile.js
@@ -77,9 +77,14 @@ export default class ResourcePile extends Resource {
             ctx.fillStyle = 'brown'; // Placeholder color for wood piles
             ctx.fillRect(this.x * this.tileSize, this.y * this.tileSize, this.tileSize, this.tileSize);
         }
+        ctx.save();
         ctx.fillStyle = 'white';
         ctx.font = '10px Arial';
+        ctx.shadowColor = 'rgba(0, 0, 0, 0.5)';
+        ctx.shadowOffsetX = 1;
+        ctx.shadowOffsetY = 1;
         ctx.fillText(this.quantity, this.x * this.tileSize + 5, this.y * this.tileSize + this.tileSize / 2);
+        ctx.restore();
     }
 
     serialize() {


### PR DESCRIPTION
## Summary
- render quantity text for resource piles with a subtle drop shadow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6888c7d0dca083238b6cf6db4c915e4f