### PR TITLE
Add stone wall sprite and cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Noits is a 2D medieval colony management game built entirely with vanilla JavaSc
 
 ## Buildings
 The following building types are available:
-- **Wall** – Impassable barrier for defence.
+- **Wall** – Impassable barrier for defence. Costs 1 stone to build.
 - **Floor** – Basic flooring allowing passage.
 - **Crafting Station** – Produces planks, bandages and buckets.
 - **Oven** – Bakes bread from wheat and prepares meals.

--- a/__tests__/Game.test.js
+++ b/__tests__/Game.test.js
@@ -156,7 +156,7 @@ describe('Game', () => {
             expectedTileY,
             1,
             1,
-            'wood',
+            'stone',
             0,
             1
         );

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -153,6 +153,7 @@ export const SPRITES = [
   [BUILDING_TYPES.TABLE, 'src/assets/table.png'],
   [BUILDING_TYPES.BED, 'src/assets/bed.png'],
   [BUILDING_TYPES.WELL, 'src/assets/well.png'],
+  [BUILDING_TYPES.WALL, 'src/assets/wall.png'],
   [RESOURCE_TYPES.BUCKET_WATER, 'src/assets/bucket_water.png'],
   ['wheat_1', 'src/assets/wheat_1.png'],
   ['wheat_2', 'src/assets/wheat_2.png'],

--- a/src/js/wall.js
+++ b/src/js/wall.js
@@ -3,9 +3,10 @@ import { BUILDING_TYPES, RESOURCE_TYPES } from './constants.js';
 
 export default class Wall extends Building {
     constructor(x, y, spriteManager = null) {
-        super(BUILDING_TYPES.WALL, x, y, 1, 1, RESOURCE_TYPES.WOOD, 0, 1);
+        super(BUILDING_TYPES.WALL, x, y, 1, 1, RESOURCE_TYPES.STONE, 0, 1);
         this.drawBase = false;
         this.spriteManager = spriteManager;
+        this.wallSprite = spriteManager ? spriteManager.getSprite(BUILDING_TYPES.WALL) : null;
         this.connections = { n: false, e: false, s: false, w: false };
     }
 
@@ -32,11 +33,17 @@ export default class Wall extends Building {
         }
         const x = this.x * tileSize;
         const y = this.y * tileSize;
+        const wallColor = this.material === RESOURCE_TYPES.WOOD ? '#8b4513' : '#808080';
+        if (this.wallSprite) {
+            ctx.drawImage(this.wallSprite, x, y, tileSize, tileSize);
+        } else {
+            ctx.fillStyle = wallColor;
+            ctx.fillRect(x, y, tileSize, tileSize);
+        }
+
         const half = tileSize / 2;
         const thickness = tileSize * 0.6;
-        const color = this.material === RESOURCE_TYPES.WOOD ? '#8b4513' : '#808080';
-
-        ctx.fillStyle = color;
+        ctx.fillStyle = wallColor;
         ctx.fillRect(x + half - thickness / 2, y + half - thickness / 2, thickness, thickness);
         if (this.connections.n) {
             ctx.fillRect(x + half - thickness / 2, y, thickness, half);


### PR DESCRIPTION
## Summary
- load a texture for walls
- draw the wall sprite in `Wall` and build it from stone
- mention the stone cost in README

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888d0b23c0c832392d96e3a6d5971f8