### PR TITLE
Use wood texture for floor rendering

### DIFF
--- a/src/js/building.js
+++ b/src/js/building.js
@@ -1,5 +1,5 @@
 import ResourcePile from './resourcePile.js';
-import { RESOURCE_TYPES, BUILDING_TYPE_PROPERTIES } from './constants.js';
+import { RESOURCE_TYPES, BUILDING_TYPE_PROPERTIES, BUILDING_TYPES } from './constants.js';
 
 export default class Building {
     constructor(
@@ -41,6 +41,9 @@ export default class Building {
 
         // Sprite manager assigned by the map
         this.spriteManager = null;
+
+        // Pattern cache for floor texture
+        this.floorPattern = null;
     }
 
     updateResourcesDelivered() {
@@ -119,6 +122,18 @@ export default class Building {
                 ctx.fillStyle = `rgba(169, 169, 169, ${this.buildProgress / 100})`;
                 ctx.fillRect(x, y, width, height);
             }
+            ctx.strokeStyle = 'black';
+            ctx.strokeRect(x, y, width, height);
+            return;
+        }
+
+        if (this.type === BUILDING_TYPES.FLOOR && this.spriteManager) {
+            const floorSprite = this.spriteManager.getSprite(BUILDING_TYPES.FLOOR);
+            if (!this.floorPattern && floorSprite) {
+                this.floorPattern = ctx.createPattern(floorSprite, 'repeat');
+            }
+            ctx.fillStyle = this.floorPattern || (this.material === RESOURCE_TYPES.WOOD ? '#8b4513' : '#808080');
+            ctx.fillRect(x, y, width, height);
             ctx.strokeStyle = 'black';
             ctx.strokeRect(x, y, width, height);
             return;

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -136,6 +136,7 @@ export const SPRITES = [
   [RESOURCE_TYPES.DIRT, 'src/assets/dirt.png'],
   ['wild_boar', 'src/assets/wild_boar.png'],
   [BUILDING_TYPES.WALL, 'src/assets/stone_texture.png'],
+  [BUILDING_TYPES.FLOOR, 'src/assets/wood_texture.png'],
   ['mushroom', 'src/assets/mushroom.png'],
   ['mushrooms', 'src/assets/mushrooms.png'],
   [RESOURCE_TYPES.WOOD, 'src/assets/wood.png'],


### PR DESCRIPTION
## Summary
- add wood floor sprite to constants
- draw floors with wood texture pattern

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6888d91378908323a9a09b075d700fa1