### PR TITLE
Add building stacking rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The following building types are available:
 - **Bed** – Lets settlers sleep to regain energy.
 - **Table** – Furniture for rooms.
 - **Well** – Draws water when supplied with a bucket.
+- *Note*: Only floors may share a tile with another building. All other buildings require an empty tile.
 
 ## Crafting Recipes
 Crafting stations and specialised buildings provide the following recipes:

--- a/__tests__/Game.test.js
+++ b/__tests__/Game.test.js
@@ -99,6 +99,7 @@ describe('Game', () => {
         // Mock specific methods that are called
         game.map.getTile.mockReturnValue(0); // Default to grass tile
         game.map.addBuilding = jest.fn(); // Mock addBuilding
+        game.map.getBuildingsAt = jest.fn().mockReturnValue([]);
         game.ui.setGameInstance = jest.fn();
         game.ui.update = jest.fn();
         game.ui.showFarmPlotMenu = jest.fn();

--- a/__tests__/Map.test.js
+++ b/__tests__/Map.test.js
@@ -74,3 +74,32 @@ describe('findAdjacentFreeTile', () => {
         expect(pos).toEqual({ x: 1, y: 1 });
     });
 });
+
+describe('building placement rules', () => {
+    test('cannot place building on top of another building', () => {
+        const map = new Map(5, 5, 32, { getSprite: jest.fn() });
+        const wall = new Building(BUILDING_TYPES.WALL, 2, 2, 1, 1, 'stone', 0);
+        const other = new Building(BUILDING_TYPES.BARRICADE, 2, 2, 1, 1, 'wood', 0);
+        expect(map.addBuilding(wall)).toBe(true);
+        expect(map.addBuilding(other)).toBe(false);
+        expect(map.buildings.length).toBe(1);
+    });
+
+    test('can place building on top of floor', () => {
+        const map = new Map(5, 5, 32, { getSprite: jest.fn() });
+        const floor = new Building(BUILDING_TYPES.FLOOR, 1, 1, 1, 1, 'wood', 100);
+        const wall = new Building(BUILDING_TYPES.WALL, 1, 1, 1, 1, 'stone', 0);
+        expect(map.addBuilding(floor)).toBe(true);
+        expect(map.addBuilding(wall)).toBe(true);
+        expect(map.buildings.length).toBe(2);
+    });
+
+    test('cannot place floor on existing building', () => {
+        const map = new Map(5, 5, 32, { getSprite: jest.fn() });
+        const wall = new Building(BUILDING_TYPES.WALL, 0, 0, 1, 1, 'stone', 0);
+        const floor = new Building(BUILDING_TYPES.FLOOR, 0, 0, 1, 1, 'wood', 100);
+        expect(map.addBuilding(wall)).toBe(true);
+        expect(map.addBuilding(floor)).toBe(false);
+        expect(map.buildings.length).toBe(1);
+    });
+});

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -732,6 +732,16 @@ export default class Game {
 
         if (this.buildMode && this.selectedBuilding) {
             const existingBuilding = this.map.getBuildingAt(tileX, tileY);
+            const buildingsHere = this.map.getBuildingsAt(tileX, tileY);
+            const hasNonFloor = buildingsHere.some(b => b.type !== BUILDING_TYPES.FLOOR);
+
+            if (
+                (this.selectedBuilding === BUILDING_TYPES.FLOOR && buildingsHere.length > 0) ||
+                (this.selectedBuilding !== BUILDING_TYPES.FLOOR && hasNonFloor)
+            ) {
+                debugLog('Cannot build on top of an existing building.');
+                return;
+            }
             if (
                 clickedTile === 8 &&
                 this.selectedBuilding !== BUILDING_TYPES.FLOOR &&

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -102,6 +102,14 @@ export default class Map {
     addBuilding(building) {
         building.spriteManager = this.spriteManager;
         building.map = this;
+
+        const existing = this.getBuildingsAt(building.x, building.y);
+        const hasNonFloor = existing.some(b => b.type !== BUILDING_TYPES.FLOOR);
+        if (hasNonFloor || (existing.length > 0 && building.type === BUILDING_TYPES.FLOOR)) {
+            debugWarn(`Tile ${building.x},${building.y} already has a building.`);
+            return false;
+        }
+
         this.buildings.push(building);
         if (building.type === BUILDING_TYPES.WALL && typeof building.updateConnections === 'function') {
             this.updateWallConnections(building.x, building.y);
@@ -118,6 +126,7 @@ export default class Map {
                 }
             }
         }
+        return true;
     }
 
     getTile(x, y) {
@@ -154,6 +163,10 @@ export default class Map {
         }
         // If only floors exist, return the last one
         return buildingsAtTile[buildingsAtTile.length - 1];
+    }
+
+    getBuildingsAt(x, y) {
+        return this.buildings.filter(b => b.x === x && b.y === y);
     }
 
     removeBuilding(buildingToRemove) {


### PR DESCRIPTION
## Summary
- restrict building placement so only floors may stack with other buildings
- add Map.getBuildingsAt helper and return success flag from addBuilding
- prevent overlapping buildings in Game.handleClick
- document stacking rule in README
- test new building placement logic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6888e18b6fe883238981ffc67482ae72