### PR TITLE
Increase settler sleep recovery rate

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -2,7 +2,8 @@
 
 // General constants
 export const ACTION_BEEP_URL = "data:audio/wav;base64,UklGRrQBAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YZABAACAq9Dt/P3v066DWDIUBAIOKU14o8rp+/7y2baLYDgZBgELI0Zwm8Tk+P72372TaD8eCAEIHj9ok73f9v745MSbcEYjCwEGGThgi7bZ8v776cqjeE0pDgIEFDJYg67T7/387dCrf1QvEgMCECxRfKfN6/v98dayh1w1FgQBDSZJdJ/H5vn+9Ny5j2Q7GwcBCSBCbJfA4ff/9+HAl2xCIAkBBxs7ZI+53PT++ebHn3RJJg0BBBY1XIey1vH9++vNp3xRLBACAxIvVICr0O38/e/TroNYMhQEAg4pTXijyun7/vLZtotgOBkGAQsjRnCbxOT4/vbfvZNoPx4IAQgeP2iTvd/2/vjkxJtwRiMLAQYZOGCLttny/vvpyqN4TSkOAgQUMliDrtPv/fzt0KuAVC8SAwIQLFF8p83r+/3x1rKHXDUWBAENJkl0n8fm+f703LmPZDsbBwEJIEJsl8Dh9//34cCXbEIgCQEHGztkj7nc9P755sefdEkmDQEEFjVch7LW8f37682nfFEsEAIDEi9U";
-export const SLEEP_GAIN_RATE = 0.01; // base sleep recovery per second
+// Increased base sleep recovery per second
+export const SLEEP_GAIN_RATE = 0.02;
 export const HEALTH_REGEN_RATE = 0.005; // base health regen per second at full hunger
 
 // Building types used across the game


### PR DESCRIPTION
## Summary
- tweak `SLEEP_GAIN_RATE` constant to make settlers recover energy faster

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6888f1fde8b48323808ec23a3655fb67