### PR TITLE
Allow floors under furniture

### DIFF
--- a/__tests__/Map.test.js
+++ b/__tests__/Map.test.js
@@ -1,6 +1,7 @@
 import Map from '../src/js/map.js';
 import ResourcePile from '../src/js/resourcePile.js';
 import Building from '../src/js/building.js';
+import Furniture from '../src/js/furniture.js';
 import { BUILDING_TYPES } from '../src/js/constants.js';
 
 describe('Map resource piles', () => {
@@ -94,12 +95,21 @@ describe('building placement rules', () => {
         expect(map.buildings.length).toBe(2);
     });
 
-    test('cannot place floor on existing building', () => {
+    test('cannot place floor on non-furniture building', () => {
         const map = new Map(5, 5, 32, { getSprite: jest.fn() });
         const wall = new Building(BUILDING_TYPES.WALL, 0, 0, 1, 1, 'stone', 0);
         const floor = new Building(BUILDING_TYPES.FLOOR, 0, 0, 1, 1, 'wood', 100);
         expect(map.addBuilding(wall)).toBe(true);
         expect(map.addBuilding(floor)).toBe(false);
         expect(map.buildings.length).toBe(1);
+    });
+
+    test('can place floor under furniture', () => {
+        const map = new Map(5, 5, 32, { getSprite: jest.fn() });
+        const bed = new Furniture(BUILDING_TYPES.BED, 2, 2, 1, 1, 'wood', 0);
+        const floor = new Building(BUILDING_TYPES.FLOOR, 2, 2, 1, 1, 'wood', 100);
+        expect(map.addBuilding(bed)).toBe(true);
+        expect(map.addBuilding(floor)).toBe(true);
+        expect(map.buildings.length).toBe(2);
     });
 });

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -733,10 +733,14 @@ export default class Game {
         if (this.buildMode && this.selectedBuilding) {
             const existingBuilding = this.map.getBuildingAt(tileX, tileY);
             const buildingsHere = this.map.getBuildingsAt(tileX, tileY);
+            const hasFloor = buildingsHere.some(b => b.type === BUILDING_TYPES.FLOOR);
             const hasNonFloor = buildingsHere.some(b => b.type !== BUILDING_TYPES.FLOOR);
+            const hasNonFurniture = buildingsHere.some(
+                b => b.type !== BUILDING_TYPES.FLOOR && !b.isFurniture,
+            );
 
             if (
-                (this.selectedBuilding === BUILDING_TYPES.FLOOR && buildingsHere.length > 0) ||
+                (this.selectedBuilding === BUILDING_TYPES.FLOOR && (hasFloor || hasNonFurniture)) ||
                 (this.selectedBuilding !== BUILDING_TYPES.FLOOR && hasNonFloor)
             ) {
                 debugLog('Cannot build on top of an existing building.');

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -104,8 +104,18 @@ export default class Map {
         building.map = this;
 
         const existing = this.getBuildingsAt(building.x, building.y);
+        const hasFloor = existing.some(b => b.type === BUILDING_TYPES.FLOOR);
         const hasNonFloor = existing.some(b => b.type !== BUILDING_TYPES.FLOOR);
-        if (hasNonFloor || (existing.length > 0 && building.type === BUILDING_TYPES.FLOOR)) {
+        const hasNonFurniture = existing.some(
+            b => b.type !== BUILDING_TYPES.FLOOR && !b.isFurniture,
+        );
+
+        if (building.type === BUILDING_TYPES.FLOOR) {
+            if (hasFloor || hasNonFurniture) {
+                debugWarn(`Tile ${building.x},${building.y} already has a building.`);
+                return false;
+            }
+        } else if (hasNonFloor) {
             debugWarn(`Tile ${building.x},${building.y} already has a building.`);
             return false;
         }


### PR DESCRIPTION
## Summary
- allow placing a floor under furniture items
- mirror the rule in Game logic
- test for placing floors under furniture

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6888f27c5260832390e0ec59403c3d57