### PR TITLE
Add door furniture

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The following building types are available:
 - **Animal Pen** – Houses livestock.
 - **Barricade** – Simple defensive structure.
 - **Bed** – Lets settlers sleep to regain energy.
+- **Door** – Allows settlers to pass while blocking enemies.
 - **Table** – Furniture for rooms.
 - **Well** – Draws water when supplied with a bucket.
 - *Note*: Only floors may share a tile with another building. All other buildings require an empty tile.

--- a/__tests__/Door.test.js
+++ b/__tests__/Door.test.js
@@ -1,0 +1,38 @@
+import { findPath } from '../src/js/pathfinding.js';
+import { BUILDING_TYPES } from '../src/js/constants.js';
+
+class MockMap {
+    constructor(tiles, buildings = []) {
+        this.tiles = tiles;
+        this.buildings = buildings;
+        this.width = tiles[0].length;
+        this.height = tiles.length;
+    }
+    getTile(x, y) {
+        return this.tiles[y][x];
+    }
+    getBuildingAt(x, y) {
+        return this.buildings.find(b => b.x === x && b.y === y) || null;
+    }
+}
+
+describe('door passability', () => {
+    test('settlers can pass through doors', () => {
+        const tiles = [[0,0,0]];
+        const buildings = [{ x: 1, y: 0, type: BUILDING_TYPES.DOOR }];
+        const map = new MockMap(tiles, buildings);
+        const path = findPath({ x: 0, y: 0 }, { x: 2, y: 0 }, map);
+        expect(path).toEqual([
+            { x: 1, y: 0 },
+            { x: 2, y: 0 }
+        ]);
+    });
+
+    test('enemies cannot pass through doors', () => {
+        const tiles = [[0,0,0]];
+        const buildings = [{ x: 1, y: 0, type: BUILDING_TYPES.DOOR }];
+        const map = new MockMap(tiles, buildings);
+        const path = findPath({ x: 0, y: 0 }, { x: 2, y: 0 }, map, true);
+        expect(path).toBeNull();
+    });
+});

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -23,6 +23,8 @@ export default class Building {
         this.maxHealth = 100; // Max health for destruction
         this.health = this.maxHealth; // Current health
         this.passable = BUILDING_TYPE_PROPERTIES[this.type]?.passable ?? true;
+        this.enemyPassable =
+            BUILDING_TYPE_PROPERTIES[this.type]?.enemyPassable ?? this.passable;
 
         // New properties for resource delivery
         this.constructionMaterials =
@@ -166,7 +168,8 @@ export default class Building {
             maxHealth: this.maxHealth,
             health: this.health,
             inventory: this.inventory,
-            passable: this.passable
+            passable: this.passable,
+            enemyPassable: this.enemyPassable
         };
     }
 
@@ -190,6 +193,10 @@ export default class Building {
         this.health = data.health;
         this.inventory = data.inventory || {};
         this.passable = data.passable ?? BUILDING_TYPE_PROPERTIES[this.type]?.passable ?? true;
+        this.enemyPassable =
+            data.enemyPassable ??
+            BUILDING_TYPE_PROPERTIES[this.type]?.enemyPassable ??
+            this.passable;
         this.updateResourcesDelivered();
     }
 }

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -17,6 +17,7 @@ export const BUILDING_TYPES = {
   BARRICADE: 'barricade',
   BED: 'bed',
   TABLE: 'table',
+  DOOR: 'door',
   WELL: 'well'
 };
 
@@ -31,6 +32,7 @@ export const BUILDING_TYPE_PROPERTIES = {
   [BUILDING_TYPES.BARRICADE]: { passable: true },
   [BUILDING_TYPES.BED]: { passable: true },
   [BUILDING_TYPES.TABLE]: { passable: true },
+  [BUILDING_TYPES.DOOR]: { passable: true, enemyPassable: false },
   [BUILDING_TYPES.WELL]: { passable: true }
 };
 
@@ -155,6 +157,7 @@ export const SPRITES = [
   [RESOURCE_TYPES.MEAL, 'src/assets/meal.png'],
   [BUILDING_TYPES.TABLE, 'src/assets/table.png'],
   [BUILDING_TYPES.BED, 'src/assets/bed.png'],
+  [BUILDING_TYPES.DOOR, 'src/assets/door.png'],
   [BUILDING_TYPES.WELL, 'src/assets/well.png'],
   [RESOURCE_TYPES.BUCKET_WATER, 'src/assets/bucket_water.png'],
   ['wheat_1', 'src/assets/wheat_1.png'],

--- a/src/js/enemy.js
+++ b/src/js/enemy.js
@@ -61,7 +61,8 @@ export default class Enemy {
                         this.path = findPath(
                             { x: Math.floor(this.x), y: Math.floor(this.y) },
                             { x: targetX, y: targetY },
-                            this.map
+                            this.map,
+                            true
                         );
                         if (!this.path) {
                             this.path = [{ x: targetX, y: targetY }];

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -773,6 +773,8 @@ export default class Game {
                 newBuilding = new AnimalPen(tileX, tileY);
             } else if (this.selectedBuilding === BUILDING_TYPES.BED) {
                 newBuilding = new Furniture(BUILDING_TYPES.BED, tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 50, this.spriteManager);
+            } else if (this.selectedBuilding === BUILDING_TYPES.DOOR) {
+                newBuilding = new Furniture(BUILDING_TYPES.DOOR, tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 0, this.spriteManager);
             } else if (this.selectedBuilding === BUILDING_TYPES.TABLE) {
                 newBuilding = new Furniture(BUILDING_TYPES.TABLE, tileX, tileY, 1, 1, RESOURCE_TYPES.WOOD, 75, this.spriteManager);
             } else if (this.selectedBuilding === BUILDING_TYPES.OVEN) {

--- a/src/js/pathfinding.js
+++ b/src/js/pathfinding.js
@@ -2,7 +2,7 @@
 import { BUILDING_TYPE_PROPERTIES } from './constants.js';
 
 // A* pathfinding algorithm
-export function findPath(start, end, map) {
+export function findPath(start, end, map, forEnemy = false) {
     if (start.x === end.x && start.y === end.y) {
         return [];
     }
@@ -31,7 +31,7 @@ export function findPath(start, end, map) {
         openSet.splice(openSet.indexOf(current), 1);
         closedSet.push(current);
 
-        const neighbors = getNeighbors(current, map);
+        const neighbors = getNeighbors(current, map, forEnemy);
         for (const neighbor of neighbors) {
             if (closedSet.some(node => node.x === neighbor.x && node.y === neighbor.y)) {
                 continue;
@@ -59,14 +59,16 @@ function heuristic(a, b) {
     return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
 }
 
-function getNeighbors(node, map) {
+function getNeighbors(node, map, forEnemy = false) {
     const neighbors = [];
     const { x, y } = node;
 
     const currentTile = map.getTile ? map.getTile(x, y) : 0;
     const currentBuilding = map.getBuildingAt ? map.getBuildingAt(x, y) : null;
     const currentBuildingPassable = currentBuilding
-        ? BUILDING_TYPE_PROPERTIES[currentBuilding.type]?.passable !== false
+        ? (forEnemy
+              ? BUILDING_TYPE_PROPERTIES[currentBuilding.type]?.enemyPassable !== false
+              : BUILDING_TYPE_PROPERTIES[currentBuilding.type]?.passable !== false)
         : false;
     const isUnpassable =
         (currentTile === 8 && !currentBuildingPassable) ||
@@ -77,7 +79,9 @@ function getNeighbors(node, map) {
             const tile = map.getTile ? map.getTile(nx, ny) : 0;
             const b = map.getBuildingAt ? map.getBuildingAt(nx, ny) : null;
             const buildingPassable = b
-                ? BUILDING_TYPE_PROPERTIES[b.type]?.passable !== false
+                ? forEnemy
+                    ? BUILDING_TYPE_PROPERTIES[b.type]?.enemyPassable !== false
+                    : BUILDING_TYPE_PROPERTIES[b.type]?.passable !== false
                 : true;
 
             if (tile === 8 && (!b || !buildingPassable)) return;

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -439,6 +439,7 @@ export default class UI {
                 break;
             case 'furniture':
                 createButton('Place Bed', BUILDING_TYPES.BED, false, 'Provides a place for settlers to sleep.');
+                createButton('Place Door', BUILDING_TYPES.DOOR, false, 'Doors block enemies but allow settlers through.');
                 createButton('Place Table', BUILDING_TYPES.TABLE, false, 'A surface for various activities.');
                 break;
             case 'zones':


### PR DESCRIPTION
## Summary
- add door furniture type and enemy-only blocking
- allow placement from furniture menu
- block enemies in pathfinding logic
- include door in save/load and README listing
- remove door sprite file (already provided elsewhere)

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688911e1bc788323a443adfef51d0e23