### PR TITLE
Implement persistent build mode

### DIFF
--- a/__tests__/Game.test.js
+++ b/__tests__/Game.test.js
@@ -174,8 +174,8 @@ describe('Game', () => {
         const haulTask = game.taskManager.addTask.mock.calls[0][0];
         expect(haulTask.type).toBe(TASK_TYPES.HAUL);
         expect(haulTask.building).toEqual(expect.any(Object));
-        expect(game.buildMode).toBe(false);
-        expect(game.selectedBuilding).toBe(null);
+        expect(game.buildMode).toBe(true);
+        expect(game.selectedBuilding).toBe(BUILDING_TYPES.WALL);
     });
 
     test('handleClick should not create haul task for farm plot', () => {

--- a/__tests__/UI.test.js
+++ b/__tests__/UI.test.js
@@ -87,6 +87,31 @@ describe('UI tooltips', () => {
         expect(button.parentElement).toBe(ui.devMenu);
     });
 
+    test('build button toggles and highlights', () => {
+        const ui = new UI({});
+        const mockGame = {
+            buildMode: false,
+            selectedBuilding: null,
+            toggleBuildMode: jest.fn(function (type) {
+                if (this.selectedBuilding === type && this.buildMode) {
+                    this.buildMode = false;
+                    this.selectedBuilding = null;
+                } else {
+                    this.buildMode = true;
+                    this.selectedBuilding = type;
+                }
+            }),
+        };
+        ui.setGameInstance(mockGame);
+        ui.showBuildCategory('buildings');
+        const button = Array.from(ui.buildMenuContent.querySelectorAll('button')).find(b => b.textContent === 'Build Wall');
+        button.dispatchEvent(new Event('click'));
+        expect(mockGame.toggleBuildMode).toHaveBeenCalledWith('wall');
+        expect(button.classList.contains('active')).toBe(true);
+        button.dispatchEvent(new Event('click'));
+        expect(button.classList.contains('active')).toBe(false);
+    });
+
     test('showSettlerOverview displays settlers', () => {
         const ui = new UI({});
         const settlers = [

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -25,6 +25,11 @@ button:hover {
     background-color: #666;
 }
 
+button.active {
+    background-color: #888;
+    border-color: #aaa;
+}
+
 input[type="range"] {
     accent-color: #4caf50;
 }

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -822,8 +822,7 @@ export default class Game {
                 ),
             );
             this.soundManager.play('action');
-            this.buildMode = false; // Exit build mode after placing
-            this.selectedBuilding = null;
+            // Keep build mode active until toggled off
         } else {
             // Check if an enemy corpse was clicked first
             const clickedEnemy = this.enemies.find(

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -107,6 +107,9 @@ export default class UI {
         this.devMenu.id = 'dev-menu-content';
         this.buildMenu.appendChild(this.devMenu);
 
+        // Track build buttons for toggling
+        this.buildButtons = new Map();
+
         this.createBuildMenuTabs();
         this.showBuildCategory('buildings'); // Default category
 
@@ -407,6 +410,7 @@ export default class UI {
 
     showBuildCategory(categoryId) {
         this.buildMenuContent.innerHTML = ''; // Clear previous content
+        this.buildButtons.clear();
 
         const createButton = (text, buildModeType, isRoomDesignation = false, tooltipText = '') => {
             const button = document.createElement('button');
@@ -421,9 +425,13 @@ export default class UI {
                     } else {
                         this.gameInstance.toggleBuildMode(buildModeType);
                     }
+                    this.updateBuildButtonHighlights();
                 }
             };
             this.buildMenuContent.appendChild(button);
+            if (!isRoomDesignation) {
+                this.buildButtons.set(buildModeType, button);
+            }
         };
 
         switch (categoryId) {
@@ -448,10 +456,24 @@ export default class UI {
                 createButton('Dig Dirt', TASK_TYPES.DIG_DIRT, true, 'Designates a tile to be dug.');
                 break;
         }
+
+        this.updateBuildButtonHighlights();
     }
 
     setGameInstance(gameInstance) {
         this.gameInstance = gameInstance;
+    }
+
+    updateBuildButtonHighlights() {
+        if (!this.gameInstance) return;
+        this.buildButtons.forEach((btn, type) => {
+            const active = this.gameInstance.buildMode && this.gameInstance.selectedBuilding === type;
+            if (active) {
+                btn.classList.add('active');
+            } else {
+                btn.classList.remove('active');
+            }
+        });
     }
 
     update(gameTime, temperature) {


### PR DESCRIPTION
## Summary
- keep build mode active after placing a building
- track build buttons in UI and highlight the active one
- add `.active` button style
- test build button toggle behaviour
- update expectations for persistent build mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889a5d5de74832389d336b0a7222ab0