### PR TITLE
Add accordion skill view in settler overview

### DIFF
--- a/__tests__/UI.test.js
+++ b/__tests__/UI.test.js
@@ -123,9 +123,26 @@ describe('UI tooltips', () => {
         ui.showSettlerOverview();
         expect(ui.settlerOverlay.style.display).toBe('block');
         expect(ui.settlerOverlay.querySelector('table')).not.toBeNull();
-        expect(ui.settlerOverlay.querySelectorAll('tbody tr').length).toBe(2);
+        expect(ui.settlerOverlay.querySelectorAll('tbody .settler-row').length).toBe(2);
         ui.hideSettlerOverview();
         expect(ui.settlerOverlay.style.display).toBe('none');
+    });
+
+    test('clicking settler row toggles skill display', () => {
+        const ui = new UI({});
+        const settlers = [
+            { name: 'Alice', currentTask: null, health: 100, hunger: 100, sleep: 100, mood: 100, carrying: null, skills: { farming: 1 } }
+        ];
+        const mockGame = { settlers };
+        ui.setGameInstance(mockGame);
+        ui.showSettlerOverview();
+        const row = ui.settlerTbody.querySelector('.settler-row');
+        const skillRow = row.nextSibling;
+        expect(skillRow.style.display).toBe('none');
+        row.dispatchEvent(new Event('click'));
+        expect(skillRow.style.display).toBe('table-row');
+        row.dispatchEvent(new Event('click'));
+        expect(skillRow.style.display).toBe('none');
     });
 
     test('wheel on settler overlay does not bubble to window', () => {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -156,6 +156,10 @@ input[type="range"] {
     padding: 5px;
 }
 
+#settler-overlay .settler-skill-row td {
+    background-color: #222;
+}
+
 #settler-overlay .close-button {
     position: absolute;
     top: 5px;

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -676,6 +676,7 @@ export default class UI {
         tbody.innerHTML = '';
         settlers.forEach(settler => {
             const row = document.createElement('tr');
+            row.className = 'settler-row';
             const cells = [
                 settler.name,
                 settler.currentTask ? settler.currentTask.type : '',
@@ -690,7 +691,24 @@ export default class UI {
                 td.textContent = text;
                 row.appendChild(td);
             });
+
+            const skillRow = document.createElement('tr');
+            skillRow.className = 'settler-skill-row';
+            skillRow.style.display = 'none';
+            const skillCell = document.createElement('td');
+            skillCell.colSpan = cells.length;
+            const skills = settler.skills || {};
+            skillCell.textContent = Object.entries(skills)
+                .map(([skill, level]) => `${skill}: ${level}`)
+                .join(', ');
+            skillRow.appendChild(skillCell);
+
+            row.addEventListener('click', () => {
+                skillRow.style.display = skillRow.style.display === 'none' ? 'table-row' : 'none';
+            });
+
             tbody.appendChild(row);
+            tbody.appendChild(skillRow);
         });
     }
 


### PR DESCRIPTION
## Summary
- toggle skill details in settler overview
- style expanded skill rows
- test accordion functionality

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889aaba578083239f1232469231bcd9