### PR TITLE
Randomize settler skills and save them

### DIFF
--- a/__tests__/Enemy.test.js
+++ b/__tests__/Enemy.test.js
@@ -6,6 +6,15 @@ describe('Enemy', () => {
     let mockResourceManager;
     let mockMap;
     let mockRoomManager;
+    const defaultSkills = {
+        farming: 1,
+        mining: 1,
+        building: 1,
+        crafting: 1,
+        cooking: 1,
+        combat: 1,
+        medical: 1,
+    };
 
     beforeEach(() => {
         mockResourceManager = {
@@ -18,7 +27,7 @@ describe('Enemy', () => {
     });
 
     test('dealDamage considers target armor', () => {
-        const target = new Settler('Target', 0, 0, mockResourceManager, mockMap, mockRoomManager);
+        const target = new Settler('Target', 0, 0, mockResourceManager, mockMap, mockRoomManager, undefined, undefined, defaultSkills);
         const helmet = new Armor('Helmet', 'light', 2, 'head');
         target.equipArmor(helmet);
         jest.spyOn(target, 'takeDamage');
@@ -33,7 +42,7 @@ describe('Enemy', () => {
     });
 
     test('update attacks target when in range', () => {
-        const target = new Settler('Target', 0, 0, mockResourceManager, mockMap, mockRoomManager);
+        const target = new Settler('Target', 0, 0, mockResourceManager, mockMap, mockRoomManager, undefined, undefined, defaultSkills);
         const enemy = new Enemy('Raider', 0, 0, target, mockMap);
         enemy.attackCooldown = 0;
         jest.spyOn(enemy, 'dealDamage').mockImplementation(() => {});

--- a/__tests__/Game.test.js
+++ b/__tests__/Game.test.js
@@ -94,7 +94,28 @@ describe('Game', () => {
         game.ui = new UI();
         game.resourceManager = new ResourceManager();
         game.taskManager = new TaskManager();
-        game.settlers = [new Settler("Alice", 5, 5, game.resourceManager)];
+        const defaultSkills = {
+            farming: 1,
+            mining: 1,
+            building: 1,
+            crafting: 1,
+            cooking: 1,
+            combat: 1,
+            medical: 1,
+        };
+        game.settlers = [
+            new Settler(
+                "Alice",
+                5,
+                5,
+                game.resourceManager,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                defaultSkills,
+            ),
+        ];
 
         // Mock specific methods that are called
         game.map.getTile.mockReturnValue(0); // Default to grass tile

--- a/__tests__/GameAutoPauseTask.test.js
+++ b/__tests__/GameAutoPauseTask.test.js
@@ -16,7 +16,26 @@ describe('Game auto pause task', () => {
 
         const ctx = { canvas: { width: 800, height: 600 }, clearRect: jest.fn(), drawImage: jest.fn() };
         const game = new Game(ctx);
-        const alice = new Settler('Alice', 0, 0, game.resourceManager, game.map, game.roomManager, game.spriteManager, game.settlers);
+        const defaultSkills = {
+            farming: 1,
+            mining: 1,
+            building: 1,
+            crafting: 1,
+            cooking: 1,
+            combat: 1,
+            medical: 1,
+        };
+        const alice = new Settler(
+            'Alice',
+            0,
+            0,
+            game.resourceManager,
+            game.map,
+            game.roomManager,
+            game.spriteManager,
+            game.settlers,
+            defaultSkills,
+        );
         alice.updateNeeds = jest.fn();
         alice.state = 'idle';
         game.settlers = [alice];

--- a/__tests__/GameDeleteTask.test.js
+++ b/__tests__/GameDeleteTask.test.js
@@ -7,7 +7,26 @@ describe('Game delete task', () => {
     test('deleteTask unassigns the settler', () => {
         const ctx = { canvas: { width: 800, height: 600 }, clearRect: jest.fn(), drawImage: jest.fn() };
         const game = new Game(ctx);
-        const alice = new Settler('Alice', 0, 0, game.resourceManager, game.map, game.roomManager, game.spriteManager, game.settlers);
+        const defaultSkills = {
+            farming: 1,
+            mining: 1,
+            building: 1,
+            crafting: 1,
+            cooking: 1,
+            combat: 1,
+            medical: 1,
+        };
+        const alice = new Settler(
+            'Alice',
+            0,
+            0,
+            game.resourceManager,
+            game.map,
+            game.roomManager,
+            game.spriteManager,
+            game.settlers,
+            defaultSkills,
+        );
         alice.updateNeeds = jest.fn();
         alice.state = 'idle';
         game.settlers = [alice];

--- a/__tests__/GameGatheringBehavior.test.js
+++ b/__tests__/GameGatheringBehavior.test.js
@@ -7,7 +7,26 @@ describe('Game gathering behavior', () => {
     test('settler carrying resource ignores new gather tasks', () => {
         const ctx = { canvas: { width: 800, height: 600 }, clearRect: jest.fn(), drawImage: jest.fn() };
         const game = new Game(ctx);
-        const settler = new Settler('Bob', 0, 0, game.resourceManager, game.map, game.roomManager, game.spriteManager, game.settlers);
+        const defaultSkills = {
+            farming: 1,
+            mining: 1,
+            building: 1,
+            crafting: 1,
+            cooking: 1,
+            combat: 1,
+            medical: 1,
+        };
+        const settler = new Settler(
+            'Bob',
+            0,
+            0,
+            game.resourceManager,
+            game.map,
+            game.roomManager,
+            game.spriteManager,
+            game.settlers,
+            defaultSkills,
+        );
         settler.updateNeeds = jest.fn();
         settler.carrying = { type: 'wood', quantity: 1 };
         settler.state = 'idle';

--- a/__tests__/GameHaulingBehavior.test.js
+++ b/__tests__/GameHaulingBehavior.test.js
@@ -10,7 +10,26 @@ describe('Game hauling behavior', () => {
     test('settler carrying resource ignores haul tasks', () => {
         const ctx = { canvas: { width: 800, height: 600 }, clearRect: jest.fn(), drawImage: jest.fn() };
         const game = new Game(ctx);
-        const settler = new Settler('Bob', 0, 0, game.resourceManager, game.map, game.roomManager, game.spriteManager, game.settlers);
+        const defaultSkills = {
+            farming: 1,
+            mining: 1,
+            building: 1,
+            crafting: 1,
+            cooking: 1,
+            combat: 1,
+            medical: 1,
+        };
+        const settler = new Settler(
+            'Bob',
+            0,
+            0,
+            game.resourceManager,
+            game.map,
+            game.roomManager,
+            game.spriteManager,
+            game.settlers,
+            defaultSkills,
+        );
         settler.updateNeeds = jest.fn();
         settler.carrying = { type: 'wood', quantity: 1 };
         settler.state = 'idle';

--- a/__tests__/GamePauseTask.test.js
+++ b/__tests__/GamePauseTask.test.js
@@ -7,8 +7,37 @@ describe('Game pause task', () => {
     test('pauseTask unassigns settler and prevents reassignment until unpaused', () => {
         const ctx = { canvas: { width: 800, height: 600 }, clearRect: jest.fn(), drawImage: jest.fn() };
         const game = new Game(ctx);
-        const alice = new Settler('Alice', 0, 0, game.resourceManager, game.map, game.roomManager, game.spriteManager, game.settlers);
-        const bob = new Settler('Bob', 0, 0, game.resourceManager, game.map, game.roomManager, game.spriteManager, game.settlers);
+        const defaultSkills = {
+            farming: 1,
+            mining: 1,
+            building: 1,
+            crafting: 1,
+            cooking: 1,
+            combat: 1,
+            medical: 1,
+        };
+        const alice = new Settler(
+            'Alice',
+            0,
+            0,
+            game.resourceManager,
+            game.map,
+            game.roomManager,
+            game.spriteManager,
+            game.settlers,
+            { ...defaultSkills },
+        );
+        const bob = new Settler(
+            'Bob',
+            0,
+            0,
+            game.resourceManager,
+            game.map,
+            game.roomManager,
+            game.spriteManager,
+            game.settlers,
+            { ...defaultSkills },
+        );
         alice.updateNeeds = jest.fn();
         bob.updateNeeds = jest.fn();
         alice.state = 'idle';

--- a/__tests__/GameUnassignTask.test.js
+++ b/__tests__/GameUnassignTask.test.js
@@ -7,8 +7,37 @@ describe('Game unassign task', () => {
     test('unassignTask clears assignment and reassigns when idle settler available', () => {
         const ctx = { canvas: { width: 800, height: 600 }, clearRect: jest.fn(), drawImage: jest.fn() };
         const game = new Game(ctx);
-        const alice = new Settler('Alice', 0, 0, game.resourceManager, game.map, game.roomManager, game.spriteManager, game.settlers);
-        const bob = new Settler('Bob', 0, 0, game.resourceManager, game.map, game.roomManager, game.spriteManager, game.settlers);
+        const defaultSkills = {
+            farming: 1,
+            mining: 1,
+            building: 1,
+            crafting: 1,
+            cooking: 1,
+            combat: 1,
+            medical: 1,
+        };
+        const alice = new Settler(
+            'Alice',
+            0,
+            0,
+            game.resourceManager,
+            game.map,
+            game.roomManager,
+            game.spriteManager,
+            game.settlers,
+            { ...defaultSkills },
+        );
+        const bob = new Settler(
+            'Bob',
+            0,
+            0,
+            game.resourceManager,
+            game.map,
+            game.roomManager,
+            game.spriteManager,
+            game.settlers,
+            { ...defaultSkills },
+        );
         alice.updateNeeds = jest.fn();
         bob.updateNeeds = jest.fn();
         alice.state = 'idle';

--- a/__tests__/Settler.test.js
+++ b/__tests__/Settler.test.js
@@ -37,7 +37,16 @@ describe('Settler', () => {
             addResourceToStorage: jest.fn(),
             findStorageRoomAndTile: jest.fn()
         };
-        settler = new Settler('TestSettler', 0, 0, mockResourceManager, mockMap, mockRoomManager);
+        const defaultSkills = {
+            farming: 1,
+            mining: 1,
+            building: 1,
+            crafting: 1,
+            cooking: 1,
+            combat: 1,
+            medical: 1,
+        };
+        settler = new Settler('TestSettler', 0, 0, mockResourceManager, mockMap, mockRoomManager, undefined, undefined, defaultSkills);
     });
 
     test('should initialize with correct properties', () => {
@@ -516,7 +525,16 @@ describe('Settler', () => {
     });
 
     test('should use bandage pile for treatment', () => {
-        const patient = new Settler('Patient', 0, 0, mockResourceManager, mockMap, mockRoomManager);
+        const defaultSkills = {
+            farming: 1,
+            mining: 1,
+            building: 1,
+            crafting: 1,
+            cooking: 1,
+            combat: 1,
+            medical: 1,
+        };
+        const patient = new Settler('Patient', 0, 0, mockResourceManager, mockMap, mockRoomManager, undefined, undefined, defaultSkills);
         patient.bodyParts.head.bleeding = true;
         mockMap.resourcePiles.push(new ResourcePile('bandage', 1, 0, 0, 1, { getSprite: jest.fn() }));
         const task = new Task('treatment', 0, 0, null, 0, 5, null, null, null, null, null, patient);
@@ -534,7 +552,16 @@ describe('Settler', () => {
     });
 
     test('should haul bandage to patient before treatment', () => {
-        const patient = new Settler('Patient', 0, 0, mockResourceManager, mockMap, mockRoomManager);
+        const defaultSkills = {
+            farming: 1,
+            mining: 1,
+            building: 1,
+            crafting: 1,
+            cooking: 1,
+            combat: 1,
+            medical: 1,
+        };
+        const patient = new Settler('Patient', 0, 0, mockResourceManager, mockMap, mockRoomManager, undefined, undefined, defaultSkills);
         patient.bodyParts.head.bleeding = true;
         mockMap.resourcePiles.push(new ResourcePile('bandage', 1, 1, 0, 1, { getSprite: jest.fn() }));
         const task = new Task('treatment', 0, 0, null, 0, 5, null, null, null, null, null, patient);
@@ -568,7 +595,16 @@ describe('Settler', () => {
     });
 
     test('settler can treat themselves', () => {
-        const patient = new Settler('SelfHealer', 0, 0, mockResourceManager, mockMap, mockRoomManager);
+        const defaultSkills = {
+            farming: 1,
+            mining: 1,
+            building: 1,
+            crafting: 1,
+            cooking: 1,
+            combat: 1,
+            medical: 1,
+        };
+        const patient = new Settler('SelfHealer', 0, 0, mockResourceManager, mockMap, mockRoomManager, undefined, undefined, defaultSkills);
         patient.bodyParts.head.bleeding = true;
         mockMap.resourcePiles.push(new ResourcePile('bandage', 1, 0, 0, 1, { getSprite: jest.fn() }));
         const task = new Task('treatment', 0, 0, null, 0, 5, null, null, null, null, null, patient);

--- a/__tests__/SettlerCombat.test.js
+++ b/__tests__/SettlerCombat.test.js
@@ -17,7 +17,16 @@ describe('Settler Health and Combat', () => {
         };
         mockMap = { removeResourceNode: jest.fn(), worldMap: { discoverLocation: jest.fn() } };
         mockRoomManager = { rooms: [], getRoomAt: jest.fn(), addResourceToStorage: jest.fn() };
-        settler = new Settler('TestSettler', 0, 0, mockResourceManager, mockMap, mockRoomManager);
+        const defaultSkills = {
+            farming: 1,
+            mining: 1,
+            building: 1,
+            crafting: 1,
+            cooking: 1,
+            combat: 1,
+            medical: 1,
+        };
+        settler = new Settler('TestSettler', 0, 0, mockResourceManager, mockMap, mockRoomManager, undefined, undefined, defaultSkills);
     });
 
     test('takeDamage sets body part health and bleeding', () => {
@@ -49,12 +58,21 @@ describe('Settler Health and Combat', () => {
     });
 
     test('dealDamage uses weapon, combat skill and target armor', () => {
-        const attacker = new Settler('Attacker', 0, 0, mockResourceManager, mockMap, mockRoomManager);
+        const defaultSkills = {
+            farming: 1,
+            mining: 1,
+            building: 1,
+            crafting: 1,
+            cooking: 1,
+            combat: 1,
+            medical: 1,
+        };
+        const attacker = new Settler('Attacker', 0, 0, mockResourceManager, mockMap, mockRoomManager, undefined, undefined, defaultSkills);
         attacker.skills.combat = 2; // +1 damage
         const sword = new Weapon('Sword', 'melee', 10, 1);
         attacker.equipWeapon(sword);
 
-        const defender = new Settler('Defender', 0, 0, mockResourceManager, mockMap, mockRoomManager);
+        const defender = new Settler('Defender', 0, 0, mockResourceManager, mockMap, mockRoomManager, undefined, undefined, { ...defaultSkills });
         const helmet = new Armor('Helmet', 'light', 1, 'head');
         defender.equipArmor(helmet);
 
@@ -81,8 +99,37 @@ describe('Settler Health and Combat', () => {
 
     test('idle allies target attacker when settler is hit', () => {
         const settlers = [];
-        const alice = new Settler('Alice', 0, 0, mockResourceManager, mockMap, mockRoomManager, undefined, settlers);
-        const bob = new Settler('Bob', 1, 1, mockResourceManager, mockMap, mockRoomManager, undefined, settlers);
+        const defaultSkills = {
+            farming: 1,
+            mining: 1,
+            building: 1,
+            crafting: 1,
+            cooking: 1,
+            combat: 1,
+            medical: 1,
+        };
+        const alice = new Settler(
+            'Alice',
+            0,
+            0,
+            mockResourceManager,
+            mockMap,
+            mockRoomManager,
+            undefined,
+            settlers,
+            { ...defaultSkills },
+        );
+        const bob = new Settler(
+            'Bob',
+            1,
+            1,
+            mockResourceManager,
+            mockMap,
+            mockRoomManager,
+            undefined,
+            settlers,
+            { ...defaultSkills },
+        );
         settlers.push(alice, bob);
 
         const enemy = new Enemy('Goblin', 1, 1, null, mockMap, { getSprite: jest.fn() });

--- a/__tests__/SettlerPathfinding.test.js
+++ b/__tests__/SettlerPathfinding.test.js
@@ -19,7 +19,26 @@ describe('Settler pathfinding frequency', () => {
         const mockResourceManager = { addResource: jest.fn(), removeResource: jest.fn(), getResourceQuantity: jest.fn() };
         const mockMap = { getTile: jest.fn(() => 0), width: 10, height: 10, resourcePiles: [], addResourcePile: jest.fn(), tileSize: 1, buildings: [] };
         const mockRoomManager = { getRoomAt: jest.fn(), addResourceToStorage: jest.fn(), findStorageRoomAndTile: jest.fn(), rooms: [] };
-        const settler = new Settler('Test', 0, 0, mockResourceManager, mockMap, mockRoomManager);
+        const defaultSkills = {
+            farming: 1,
+            mining: 1,
+            building: 1,
+            crafting: 1,
+            cooking: 1,
+            combat: 1,
+            medical: 1,
+        };
+        const settler = new Settler(
+            'Test',
+            0,
+            0,
+            mockResourceManager,
+            mockMap,
+            mockRoomManager,
+            undefined,
+            undefined,
+            defaultSkills,
+        );
         const task = new Task('move', 2, 0);
         settler.currentTask = task;
 

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -91,8 +91,30 @@ export default class Game {
         }
 
         // Create a new settler
-        this.settlers.push(new Settler("Alice", 5, 5, this.resourceManager, this.map, this.roomManager, this.spriteManager, this.settlers));
-        this.settlers.push(new Settler("Bob", 6, 5, this.resourceManager, this.map, this.roomManager, this.spriteManager, this.settlers));
+        this.settlers.push(
+            new Settler(
+                "Alice",
+                5,
+                5,
+                this.resourceManager,
+                this.map,
+                this.roomManager,
+                this.spriteManager,
+                this.settlers,
+            )
+        );
+        this.settlers.push(
+            new Settler(
+                "Bob",
+                6,
+                5,
+                this.resourceManager,
+                this.map,
+                this.roomManager,
+                this.spriteManager,
+                this.settlers,
+            )
+        );
 
         window.addEventListener('keydown', this.handleKeyDown);
         window.addEventListener('keyup', this.handleKeyUp);
@@ -589,7 +611,17 @@ export default class Game {
             // Restore settlers
             this.settlers = [];
             gameState.settlers.forEach(sData => {
-                const settler = new Settler(sData.name, sData.x, sData.y, this.resourceManager, this.map, this.roomManager, this.spriteManager, this.settlers);
+                const settler = new Settler(
+                    sData.name,
+                    sData.x,
+                    sData.y,
+                    this.resourceManager,
+                    this.map,
+                    this.roomManager,
+                    this.spriteManager,
+                    this.settlers,
+                    sData.skills,
+                );
                 settler.deserialize(sData);
                 this.settlers.push(settler);
             });

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -6,7 +6,17 @@ import { findPath } from './pathfinding.js';
 import { SLEEP_GAIN_RATE, SETTLER_RUN_SPEED, TASK_TYPES, RESOURCE_TYPES, HEALTH_REGEN_RATE, BUILDING_TYPES, FOOD_HUNGER_VALUES } from './constants.js';
 
 export default class Settler {
-    constructor(name, x, y, resourceManager, map, roomManager, spriteManager, allSettlers = null) {
+    constructor(
+        name,
+        x,
+        y,
+        resourceManager,
+        map,
+        roomManager,
+        spriteManager,
+        allSettlers = null,
+        skills = null,
+    ) {
         this.resourceManager = resourceManager;
         this.map = map;
         this.roomManager = roomManager;
@@ -32,15 +42,7 @@ export default class Settler {
         this.currentTask = null;
         this.path = null;
         this.carrying = null; // { type: "wood", quantity: 1 }
-        this.skills = {
-            farming: 1,
-            mining: 1,
-            building: 1,
-            crafting: 1,
-            cooking: 1,
-            combat: 1,
-            medical: 1
-        };
+        this.skills = skills || this.generateRandomSkills();
         this.taskPriorities = {};
         Object.values(TASK_TYPES).forEach(type => {
             this.taskPriorities[type] = 5;
@@ -54,6 +56,19 @@ export default class Settler {
         this.currentBed = null; // Reference to bed building when sleeping in one
         this.currentBuilding = null; // Building this settler is currently using
         this.showSkills = false; // Track whether the skills row is expanded in the UI
+    }
+
+    generateRandomSkills() {
+        const randomValue = () => Math.floor(Math.random() * 3) + 1; // 1-3
+        return {
+            farming: randomValue(),
+            mining: randomValue(),
+            building: randomValue(),
+            crafting: randomValue(),
+            cooking: randomValue(),
+            combat: randomValue(),
+            medical: randomValue(),
+        };
     }
 
     equipWeapon(weapon) {


### PR DESCRIPTION
## Summary
- randomize settler skills at creation
- keep randomized skills in saved game data
- adjust game loading to pass skills
- update tests for new constructor signature

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889d1ef0344832399850d7209eee422