### PR TITLE
Implement deconstruct building feature

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -106,6 +106,7 @@ export const TASK_TYPES = {
   BUTCHER: 'butcher',
   EXPLORE: 'explore',
   TREATMENT: 'treatment',
+  DECONSTRUCT: 'deconstruct',
   HAUL: 'haul',
   SLEEP: 'sleep'
 };

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -67,6 +67,7 @@ export default class Game {
         this.buildMode = false; // New property for build mode
         this.selectedBuilding = null; // New property to hold the selected building type
         this.diggingDirtMode = false; // New property for digging dirt mode
+        this.deconstructMode = false; // New property for deconstruct mode
 
         this.gameLoop = this.gameLoop.bind(this);
         this.handleKeyDown = this.handleKeyDown.bind(this);
@@ -390,8 +391,20 @@ export default class Game {
             // Exit room designation mode if active
             this.roomDesignationStart = null;
             this.selectedRoomType = null;
+            this.deconstructMode = false;
         }
         debugLog(`Build mode: ${this.buildMode}, Selected: ${this.selectedBuilding}`);
+    }
+
+    toggleDeconstructMode() {
+        this.deconstructMode = !this.deconstructMode;
+        if (this.deconstructMode) {
+            this.buildMode = false;
+            this.selectedBuilding = null;
+            this.roomDesignationStart = null;
+            this.selectedRoomType = null;
+        }
+        debugLog(`Deconstruct mode: ${this.deconstructMode}`);
     }
 
     startRoomDesignation(roomType) {
@@ -399,6 +412,7 @@ export default class Game {
         this.selectedBuilding = null;
         this.roomDesignationStart = { x: null, y: null };
         this.selectedRoomType = roomType;
+        this.deconstructMode = false;
         debugLog(`Room designation mode: ${roomType}. Click to select start tile.`);
     }
 
@@ -407,6 +421,7 @@ export default class Game {
         this.selectedBuilding = null;
         this.roomDesignationStart = null; // Exit room designation mode if active
         this.selectedRoomType = null;
+        this.deconstructMode = false;
         this.diggingDirtMode = true;
         debugLog("Digging dirt mode: Click on a grass tile to dig dirt.");
     }
@@ -762,7 +777,13 @@ export default class Game {
             return; // Room designation handled
         }
 
-        if (this.buildMode && this.selectedBuilding) {
+        if (this.deconstructMode) {
+            const building = this.map.getBuildingAt(tileX, tileY);
+            if (building) {
+                this.taskManager.addTask(new Task(TASK_TYPES.DECONSTRUCT, tileX, tileY, null, 0, 2, building));
+                debugLog(`Deconstruct task added at ${tileX},${tileY}`);
+            }
+        } else if (this.buildMode && this.selectedBuilding) {
             const existingBuilding = this.map.getBuildingAt(tileX, tileY);
             const buildingsHere = this.map.getBuildingsAt(tileX, tileY);
             const hasFloor = buildingsHere.some(b => b.type === BUILDING_TYPES.FLOOR);

--- a/src/js/settler.js
+++ b/src/js/settler.js
@@ -757,6 +757,18 @@ export default class Settler {
                         debugLog(`${this.name} tended to animals at ${animalPen.x},${animalPen.y}.`);
                         this.currentTask = null;
                         this.path = null; // Task completed immediately after action
+                    } else if (this.currentTask.type === TASK_TYPES.DECONSTRUCT && this.currentTask.building) {
+                        const building = this.currentTask.building;
+                        building.spillInventory(this.map);
+                        for (const mat in building.constructionMaterials) {
+                            const qty = building.constructionMaterials[mat];
+                            const pile = new ResourcePile(mat, qty, building.x, building.y, this.map.tileSize, this.spriteManager);
+                            this.map.addResourcePile(pile);
+                        }
+                        this.map.removeBuilding(building);
+                        debugLog(`${this.name} deconstructed building at ${building.x},${building.y}.`);
+                        this.currentTask = null;
+                        this.path = null;
                     } else if (this.currentTask.type === "eat" && this.currentTask.foodType) {
                         const room = this.roomManager.getRoomAt(this.currentTask.targetX, this.currentTask.targetY);
                         const consumed = room && room.type === "storage"

--- a/src/js/taskManager.js
+++ b/src/js/taskManager.js
@@ -19,6 +19,7 @@ export const TASK_SKILL_MAP = {
     [TASK_TYPES.BUTCHER]: 'farming',
     [TASK_TYPES.TREATMENT]: 'medical',
     [TASK_TYPES.HUNT_ANIMAL]: 'combat',
+    [TASK_TYPES.DECONSTRUCT]: 'building',
 };
 
 export default class TaskManager {

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -423,6 +423,8 @@ export default class UI {
                 if (this.gameInstance) {
                     if (isRoomDesignation) {
                         this.gameInstance.startRoomDesignation(buildModeType);
+                    } else if (buildModeType === 'remove_building') {
+                        this.gameInstance.toggleDeconstructMode();
                     } else {
                         this.gameInstance.toggleBuildMode(buildModeType);
                     }
@@ -445,6 +447,7 @@ export default class UI {
                 createButton('Build Farm Plot', BUILDING_TYPES.FARM_PLOT, false, 'Used for growing crops.');
                 createButton('Build Animal Pen', BUILDING_TYPES.ANIMAL_PEN, false, 'Houses livestock.');
                 createButton('Build Barricade', BUILDING_TYPES.BARRICADE, false, 'A simple defensive barrier.');
+                createButton('Remove Building', 'remove_building', false, 'Deconstruct a building.');
                 break;
             case 'furniture':
                 createButton('Place Bed', BUILDING_TYPES.BED, false, 'Provides a place for settlers to sleep.');
@@ -468,7 +471,9 @@ export default class UI {
     updateBuildButtonHighlights() {
         if (!this.gameInstance) return;
         this.buildButtons.forEach((btn, type) => {
-            const active = this.gameInstance.buildMode && this.gameInstance.selectedBuilding === type;
+            const active =
+                (this.gameInstance.buildMode && this.gameInstance.selectedBuilding === type) ||
+                (type === 'remove_building' && this.gameInstance.deconstructMode);
             if (active) {
                 btn.classList.add('active');
             } else {


### PR DESCRIPTION
## Summary
- add new `DECONSTRUCT` task type
- support toggling a new deconstruct mode
- add Remove Building button in the build menu
- settlers can deconstruct buildings and drop materials

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6889d882c86083239fe9f0c8129a7dcb