### PR TITLE
Start game paused

### DIFF
--- a/src/js/game.js
+++ b/src/js/game.js
@@ -127,6 +127,7 @@ export default class Game {
             }
             // Do not automatically resume when focus returns; player must unpause manually
         });
+        this.pause();
         this.gameLoop(0);
     }
 


### PR DESCRIPTION
## Summary
- pause gameplay right after event listeners in `Game.start`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6889fe2170d88323b3b221da850294bc