### PR TITLE
Centralize recipe definitions

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -172,3 +172,57 @@ export const SPRITES = [
   ['iron_ore_pile', 'src/assets/iron_ore_pile.png'],
   ['construction', 'src/assets/construction.png']
 ];
+
+// Definitions for all crafting recipes by building type
+export const CRAFTING_RECIPE_DEFINITIONS = {
+  [BUILDING_TYPES.CRAFTING_STATION]: [
+    {
+      name: 'plank',
+      inputs: [{ resourceType: RESOURCE_TYPES.WOOD, quantity: 1 }],
+      outputs: [
+        { resourceType: RESOURCE_TYPES.PLANK, quantity: 2, quality: 1 },
+      ],
+      time: 2,
+    },
+    {
+      name: 'bandage',
+      inputs: [{ resourceType: RESOURCE_TYPES.COTTON, quantity: 1 }],
+      outputs: [
+        { resourceType: RESOURCE_TYPES.BANDAGE, quantity: 1, quality: 1 },
+      ],
+      time: 3,
+    },
+    {
+      name: 'bucket',
+      inputs: [{ resourceType: RESOURCE_TYPES.PLANK, quantity: 1 }],
+      outputs: [
+        { resourceType: RESOURCE_TYPES.BUCKET, quantity: 1, quality: 1 },
+      ],
+      time: 2,
+    },
+  ],
+  [BUILDING_TYPES.OVEN]: [
+    {
+      name: 'bread',
+      inputs: [{ resourceType: RESOURCE_TYPES.WHEAT, quantity: 1 }],
+      outputs: [
+        { resourceType: RESOURCE_TYPES.BREAD, quantity: 1, quality: 1 },
+      ],
+      time: 3,
+    },
+  ],
+  [BUILDING_TYPES.WELL]: [
+    {
+      name: 'Water bucket',
+      inputs: [{ resourceType: RESOURCE_TYPES.BUCKET, quantity: 1 }],
+      outputs: [
+        {
+          resourceType: RESOURCE_TYPES.BUCKET_WATER,
+          quantity: 1,
+          quality: 1,
+        },
+      ],
+      time: 1,
+    },
+  ],
+};

--- a/src/js/craftingStation.js
+++ b/src/js/craftingStation.js
@@ -1,7 +1,7 @@
 import { debugLog } from './debug.js';
 import Building from './building.js';
 import Recipe from './recipe.js';
-import { RESOURCE_TYPES, BUILDING_TYPES } from './constants.js';
+import { RESOURCE_TYPES, BUILDING_TYPES, CRAFTING_RECIPE_DEFINITIONS } from './constants.js';
 
 export default class CraftingStation extends Building {
     constructor(x, y, spriteManager = null, constructionMaterials = null) {
@@ -19,57 +19,11 @@ export default class CraftingStation extends Building {
         this.drawBase = false;
         this.spriteManager = spriteManager;
         this.stationSprite = spriteManager ? spriteManager.getSprite(BUILDING_TYPES.CRAFTING_STATION) : null;
-        this.recipes = []; // List of recipes this station can craft
+        this.recipes = CRAFTING_RECIPE_DEFINITIONS[BUILDING_TYPES.CRAFTING_STATION].map(
+            (def) => new Recipe(def.name, def.inputs, def.outputs, def.time),
+        );
         this.autoCraft = false;
         this.desiredRecipe = null;
-
-        // 2 planks from 1 wood
-        this.addRecipe(
-            new Recipe(
-                "plank",
-                [{ resourceType: RESOURCE_TYPES.WOOD, quantity: 1 }],
-                [
-                    {
-                        resourceType: RESOURCE_TYPES.PLANK,
-                        quantity: 2,
-                        quality: 1,
-                    },
-                ],
-                2,
-            ),
-        );
-
-        // 1 bandage from 1 cotton
-        this.addRecipe(
-            new Recipe(
-                "bandage",
-                [{ resourceType: RESOURCE_TYPES.COTTON, quantity: 1 }],
-                [
-                    {
-                        resourceType: RESOURCE_TYPES.BANDAGE,
-                        quantity: 1,
-                        quality: 1,
-                    },
-                ],
-                3,
-            ),
-        );
-
-        // New recipe: Bucket from plank
-        this.addRecipe(
-            new Recipe(
-                "bucket",
-                [{ resourceType: RESOURCE_TYPES.PLANK, quantity: 1 }],
-                [
-                    {
-                        resourceType: RESOURCE_TYPES.BUCKET,
-                        quantity: 1,
-                        quality: 1,
-                    },
-                ],
-                2,
-            ),
-        );
     }
 
     addRecipe(recipe) {

--- a/src/js/oven.js
+++ b/src/js/oven.js
@@ -1,6 +1,6 @@
 import CraftingStation from './craftingStation.js';
 import Recipe from './recipe.js';
-import { RESOURCE_TYPES, BUILDING_TYPES, BUILDING_TYPE_PROPERTIES } from './constants.js';
+import { RESOURCE_TYPES, BUILDING_TYPES, BUILDING_TYPE_PROPERTIES, CRAFTING_RECIPE_DEFINITIONS } from './constants.js';
 
 export default class Oven extends CraftingStation {
     constructor(x, y, spriteManager = null) {
@@ -10,22 +10,10 @@ export default class Oven extends CraftingStation {
         this.resourcesRequired = 1;
         this.passable = BUILDING_TYPE_PROPERTIES[this.type]?.passable ?? true;
         this.stationSprite = spriteManager ? spriteManager.getSprite(BUILDING_TYPES.OVEN) : null;
-        this.recipes = [];
+        this.recipes = CRAFTING_RECIPE_DEFINITIONS[BUILDING_TYPES.OVEN].map(
+            (def) => new Recipe(def.name, def.inputs, def.outputs, def.time),
+        );
         this.autoCraft = false;
         this.desiredRecipe = null;
-        this.addRecipe(
-            new Recipe(
-                'bread',
-                [{ resourceType: RESOURCE_TYPES.WHEAT, quantity: 1 }],
-                [
-                    {
-                        resourceType: RESOURCE_TYPES.BREAD,
-                        quantity: 1,
-                        quality: 1,
-                    },
-                ],
-                3,
-            ),
-        );
     }
 }

--- a/src/js/well.js
+++ b/src/js/well.js
@@ -1,6 +1,6 @@
 import CraftingStation from './craftingStation.js';
 import Recipe from './recipe.js';
-import { BUILDING_TYPES, RESOURCE_TYPES, BUILDING_TYPE_PROPERTIES } from './constants.js';
+import { BUILDING_TYPES, RESOURCE_TYPES, BUILDING_TYPE_PROPERTIES, CRAFTING_RECIPE_DEFINITIONS } from './constants.js';
 
 export default class Well extends CraftingStation {
     constructor(x, y, spriteManager = null) {
@@ -17,17 +17,11 @@ export default class Well extends CraftingStation {
         this.resourcesDelivered = 0;
         this.passable = BUILDING_TYPE_PROPERTIES[this.type]?.passable ?? true;
         this.stationSprite = spriteManager ? spriteManager.getSprite(BUILDING_TYPES.WELL) : null;
-        this.recipes = [];
+        this.recipes = CRAFTING_RECIPE_DEFINITIONS[BUILDING_TYPES.WELL].map(
+            (def) => new Recipe(def.name, def.inputs, def.outputs, def.time),
+        );
         this.autoCraft = false;
         this.desiredRecipe = null;
         this.drawBase = false;
-        this.addRecipe(
-            new Recipe(
-                'Water bucket',
-                [{ resourceType: RESOURCE_TYPES.BUCKET, quantity: 1 }],
-                [{ resourceType: RESOURCE_TYPES.BUCKET_WATER, quantity: 1, quality: 1 }],
-                1,
-            ),
-        );
     }
 }


### PR DESCRIPTION
## Summary
- move recipe data for all stations into `CRAFTING_RECIPE_DEFINITIONS`
- construct station recipes from this shared constant

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b2c21b2c48323a3e2e99a919adb0b